### PR TITLE
Fix GitHub repo URLs and bump to 1.12.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
 
           if [ -z "$NOTES" ]; then
             echo "No changelog entry found for version $VERSION"
-            NOTES="No changelog entry found. See [CHANGELOG.md](https://github.com/rookslog/get-shit-done-reflect/blob/main/CHANGELOG.md) for details."
+            NOTES="No changelog entry found. See [CHANGELOG.md](https://github.com/loganrooks/get-shit-done-reflect/blob/main/CHANGELOG.md) for details."
           fi
 
           # Write to file for multi-line handling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For upstream GSD changelog, see [GSD Changelog](https://github.com/glittercowboy
 
 ## [Unreleased]
 
+## [1.12.1] - 2026-02-09
+
+### Fixed
+- GitHub repository URLs corrected from `rookslog` to `loganrooks` in package.json, README, update command, and publish workflow
+- CI lint job removed (unused, caused workflow parse failures)
+- Wiring validation test allowlists upstream GSD agents installed at runtime
+
 ## [1.12.0] - 2026-02-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Built on top of [GSD](https://github.com/glittercowboy/get-shit-done) by TACHES.
 
 [![npm version](https://img.shields.io/npm/v/get-shit-done-reflect-cc?style=for-the-badge&logo=npm&logoColor=white&color=CB3837)](https://www.npmjs.com/package/get-shit-done-reflect-cc)
-[![GitHub stars](https://img.shields.io/github/stars/rookslog/get-shit-done-reflect?style=for-the-badge&logo=github&color=181717)](https://github.com/rookslog/get-shit-done-reflect)
+[![GitHub stars](https://img.shields.io/github/stars/loganrooks/get-shit-done-reflect?style=for-the-badge&logo=github&color=181717)](https://github.com/loganrooks/get-shit-done-reflect)
 [![License](https://img.shields.io/badge/license-MIT-blue?style=for-the-badge)](LICENSE)
 
 <br>

--- a/commands/gsd/update.md
+++ b/commands/gsd/update.md
@@ -154,7 +154,7 @@ Format completion message (changelog was already shown in confirmation step):
 
 ⚠️  Restart Claude Code to pick up the new commands.
 
-[View full changelog](https://github.com/rookslog/get-shit-done-reflect/blob/main/CHANGELOG.md)
+[View full changelog](https://github.com/loganrooks/get-shit-done-reflect/blob/main/CHANGELOG.md)
 ```
 </step>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shit-done-reflect-cc",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "A self-improving AI coding system that learns from its mistakes. Built on GSD by TACHES.",
   "bin": {
     "get-shit-done-reflect-cc": "bin/install.js"
@@ -32,11 +32,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rookslog/get-shit-done-reflect.git"
+    "url": "git+https://github.com/loganrooks/get-shit-done-reflect.git"
   },
-  "homepage": "https://github.com/rookslog/get-shit-done-reflect",
+  "homepage": "https://github.com/loganrooks/get-shit-done-reflect",
   "bugs": {
-    "url": "https://github.com/rookslog/get-shit-done-reflect/issues"
+    "url": "https://github.com/loganrooks/get-shit-done-reflect/issues"
   },
   "engines": {
     "node": ">=16.7.0"


### PR DESCRIPTION
## Summary

- Fix GitHub repo URLs from `rookslog` to `loganrooks` in package.json, README.md, update command, and publish workflow
- Bump to 1.12.1 since 1.12.0 was published with incorrect URLs
- Add CHANGELOG entry for 1.12.1

## Test plan

- [ ] CI passes
- [ ] Merge, then publish 1.12.1 to npm with corrected metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)