### PR TITLE
docs: refresh shipped surface coverage for v1.36 (stacked 2/5)

### DIFF
--- a/docs/CLI-TOOLS.md
+++ b/docs/CLI-TOOLS.md
@@ -11,7 +11,7 @@
 **Preferred for new orchestration:** Many of the same operations are available as `gsd-sdk query <command>` (see `sdk/src/query/index.ts` and `docs/QUERY-HANDLERS.md`). Use that in workflows and examples where the handler exists; keep `node … gsd-tools.cjs` for commands not yet in the registry (for example graphify) or when you need CJS-only flags.
 
 **Location:** `get-shit-done/bin/gsd-tools.cjs`
-**Modules:** 15 domain modules in `get-shit-done/bin/lib/`
+**Modules:** see the [Module Architecture](#module-architecture) table; the `get-shit-done/bin/lib/` directory is authoritative.
 
 **Usage:**
 ```bash
@@ -368,6 +368,31 @@ node gsd-tools.cjs websearch <query> [--limit N] [--freshness day|week|month]
 
 ---
 
+## Graphify
+
+Build, query, and inspect the project knowledge graph in `.planning/graphs/`. Requires `graphify.enabled: true` in `config.json` (see [Configuration Reference](CONFIGURATION.md#graphify-settings)). Graphify is **CJS-only**: `gsd-sdk query` does not yet register graphify handlers — always use `node gsd-tools.cjs graphify …`.
+
+```bash
+# Build or rebuild the knowledge graph
+node gsd-tools.cjs graphify build
+
+# Search the graph for a term
+node gsd-tools.cjs graphify query <term>
+
+# Show graph freshness and statistics
+node gsd-tools.cjs graphify status
+
+# Show changes since the last build
+node gsd-tools.cjs graphify diff
+
+# Write a named snapshot of the current graph
+node gsd-tools.cjs graphify snapshot [name]
+```
+
+User-facing entry point: `/gsd-graphify` (see [Command Reference](COMMANDS.md#gsd-graphify)).
+
+---
+
 ## Module Architecture
 
 | Module | File | Exports |
@@ -387,3 +412,5 @@ node gsd-tools.cjs websearch <query> [--limit N] [--freshness day|week|month]
 | UAT | `lib/uat.cjs` | Cross-phase UAT/verification audit |
 | Profile Output | `lib/profile-output.cjs` | Developer profile formatting |
 | Profile Pipeline | `lib/profile-pipeline.cjs` | Session analysis pipeline |
+| Graphify | `lib/graphify.cjs` | Knowledge graph build/query/status/diff/snapshot (backs `/gsd-graphify`) |
+| Learnings | `lib/learnings.cjs` | Extract learnings from phases/SUMMARY artifacts (backs `/gsd-extract-learnings`) |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -637,17 +637,27 @@ Execute ad-hoc task with GSD guarantees.
 
 | Flag | Description |
 |------|-------------|
-| `--full` | Enable plan checking (2 iterations) + post-execution verification |
+| `--full` | Enable the complete quality pipeline — discussion + research + plan-checking + verification |
+| `--validate` | Plan-checking (max 2 iterations) + post-execution verification only; no discussion or research |
 | `--discuss` | Lightweight pre-planning discussion |
 | `--research` | Spawn focused researcher before planning |
 
-Flags are composable.
+Granular flags are composable: `--discuss --research --validate` is equivalent to `--full`.
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List all quick tasks with status |
+| `status <slug>` | Show status of a specific quick task |
+| `resume <slug>` | Resume a specific quick task by slug |
 
 ```bash
 /gsd-quick                          # Basic quick task
 /gsd-quick --discuss --research     # Discussion + research + planning
-/gsd-quick --full                   # With plan checking and verification
-/gsd-quick --discuss --research --full  # All optional stages
+/gsd-quick --validate               # Plan-checking + verification only
+/gsd-quick --full                   # Complete quality pipeline
+/gsd-quick list                     # List all quick tasks
+/gsd-quick status my-task-slug      # Show status of a quick task
+/gsd-quick resume my-task-slug      # Resume a quick task
 ```
 
 ### `/gsd-autonomous`
@@ -977,6 +987,28 @@ Query, inspect, or refresh queryable codebase intelligence files stored in `.pla
 /gsd-intel refresh                  # Rebuild intel index
 ```
 
+### `/gsd-graphify`
+
+Build, query, and inspect the project knowledge graph stored in `.planning/graphs/`. Opt-in via `graphify.enabled: true` in `config.json` (see [Configuration Reference](CONFIGURATION.md#graphify-settings)); when disabled, the command prints an activation hint and stops.
+
+| Subcommand | Description |
+|------------|-------------|
+| `build` | Build or rebuild the knowledge graph (spawns the graphify-builder agent) |
+| `query <term>` | Search the graph for a term |
+| `status` | Show graph freshness and statistics |
+| `diff` | Show changes since the last build |
+
+**Produces:** `.planning/graphs/` graph artifacts (nodes, edges, snapshots)
+
+```bash
+/gsd-graphify build                 # Build or rebuild the knowledge graph
+/gsd-graphify query authentication  # Search the graph for a term
+/gsd-graphify status                # Show freshness and statistics
+/gsd-graphify diff                  # Show changes since last build
+```
+
+**Programmatic access:** `node gsd-tools.cjs graphify <build|query|status|diff|snapshot>` — see [CLI Tools Reference](CLI-TOOLS.md).
+
 ---
 
 ## AI Integration Commands
@@ -1278,7 +1310,11 @@ Manage persistent context threads for cross-session work.
 
 | Argument | Required | Description |
 |----------|----------|-------------|
-| (none) | — | List all threads |
+| (none) / `list` | — | List all threads |
+| `list --open` | — | List threads with status `open` or `in_progress` only |
+| `list --resolved` | — | List threads with status `resolved` only |
+| `status <slug>` | — | Show status of a specific thread |
+| `close <slug>` | — | Mark a thread as resolved |
 | `name` | — | Resume existing thread by name |
 | `description` | — | Create new thread |
 
@@ -1286,6 +1322,10 @@ Threads are lightweight cross-session knowledge stores for work that spans multi
 
 ```bash
 /gsd-thread                         # List all threads
+/gsd-thread list --open             # List only open/in-progress threads
+/gsd-thread list --resolved         # List only resolved threads
+/gsd-thread status fix-deploy-key   # Show thread status
+/gsd-thread close fix-deploy-key    # Mark thread as resolved
 /gsd-thread fix-deploy-key-auth     # Resume thread
 /gsd-thread "Investigate TCP timeout in pasta service"  # Create new
 ```

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -18,7 +18,8 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
   "model_overrides": {},
   "planning": {
     "commit_docs": true,
-    "search_gitignored": false
+    "search_gitignored": false,
+    "sub_repos": []
   },
   "context_profile": null,
   "workflow": {
@@ -45,7 +46,10 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
     "code_review_command": null,
     "cross_ai_execution": false,
     "cross_ai_command": null,
-    "cross_ai_timeout": 300
+    "cross_ai_timeout": 300,
+    "security_enforcement": true,
+    "security_asvs_level": 1,
+    "security_block_on": "high"
   },
   "hooks": {
     "context_warnings": true,
@@ -80,9 +84,6 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
     "always_confirm_external_services": true
   },
   "project_code": null,
-  "security_enforcement": true,
-  "security_asvs_level": 1,
-  "security_block_on": "high",
   "agent_skills": {},
   "response_language": null,
   "features": {
@@ -164,6 +165,7 @@ All workflow toggles follow the **absent = enabled** pattern. If a key is missin
 |---------|------|---------|-------------|
 | `planning.commit_docs` | boolean | `true` | Whether `.planning/` files are committed to git |
 | `planning.search_gitignored` | boolean | `false` | Add `--no-ignore` to broad searches to include `.planning/` |
+| `planning.sub_repos` | array of strings | `[]` | Paths of nested sub-repos relative to the project root. When set, GSD-aware tooling scopes phase-lookup, path-resolution, and commit operations per sub-repo instead of treating the outer repo as a monorepo |
 
 ### Auto-Detection
 
@@ -265,6 +267,14 @@ Toggle optional capabilities via the `features.*` config namespace. Feature flag
 | `features.thinking_partner` | boolean | `false` | Enable thinking partner analysis at workflow decision points |
 | `features.global_learnings` | boolean | `false` | Enable cross-project learnings pipeline (auto-copy at phase completion, planner injection) |
 | `intel.enabled` | boolean | `false` | Enable queryable codebase intelligence system. When `true`, `/gsd-intel` commands build and query a JSON index in `.planning/intel/`. Added in v1.34 |
+
+<a id="graphify-settings"></a>
+### Graphify Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `graphify.enabled` | boolean | `false` | Enable the project knowledge graph. When `true`, `/gsd-graphify` builds and queries a graph in `.planning/graphs/`. Added in v1.36 |
+| `graphify.build_timeout` | number (seconds) | `300` | Maximum seconds allowed for a `/gsd-graphify build` run before it aborts. Added in v1.36 |
 
 ### Usage
 
@@ -368,13 +378,13 @@ Control confirmation prompts during workflows.
 
 ## Security Settings
 
-Settings for the security enforcement feature (v1.31). All follow the **absent = enabled** pattern.
+Settings for the security enforcement feature (v1.31). All follow the **absent = enabled** pattern. These keys live under `workflow.*` in `.planning/config.json` — matching the shipped template and the runtime reads in `workflows/plan-phase.md`, `workflows/execute-phase.md`, `workflows/secure-phase.md`, and `workflows/verify-work.md`.
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `security_enforcement` | boolean | `true` | Enable threat-model-anchored security verification via `/gsd-secure-phase`. When `false`, security checks are skipped entirely |
-| `security_asvs_level` | number (1-3) | `1` | OWASP ASVS verification level. Level 1 = opportunistic, Level 2 = standard, Level 3 = comprehensive |
-| `security_block_on` | string | `"high"` | Minimum severity that blocks phase advancement. Options: `"high"`, `"medium"`, `"low"` |
+| `workflow.security_enforcement` | boolean | `true` | Enable threat-model-anchored security verification via `/gsd-secure-phase`. When `false`, security checks are skipped entirely |
+| `workflow.security_asvs_level` | number (1-3) | `1` | OWASP ASVS verification level. Level 1 = opportunistic, Level 2 = standard, Level 3 = comprehensive |
+| `workflow.security_block_on` | string | `"high"` | Minimum severity that blocks phase advancement. Options: `"high"`, `"medium"`, `"low"` |
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -116,6 +116,8 @@
   - [SDK Workstream Support](#113-sdk-workstream-support)
   - [Context-Window-Aware Prompt Thinning](#114-context-window-aware-prompt-thinning)
   - [Configurable CLAUDE.md Path](#115-configurable-claudemd-path)
+  - [TDD Pipeline Mode](#116-tdd-pipeline-mode)
+  - [Knowledge Graph Integration](#117-knowledge-graph-integration)
 - [v1.32 Features](#v132-features)
   - [STATE.md Consistency Gates](#69-statemd-consistency-gates)
   - [Autonomous `--to N` Flag](#70-autonomous---to-n-flag)
@@ -2423,3 +2425,19 @@ Test suite that scans all agent, workflow, and command files for embedded inject
 
 **Configuration:** `workflow.tdd_mode`
 **Reference files:** `tdd.md`, `checkpoints.md`
+
+---
+
+### 117. Knowledge Graph Integration
+
+**Purpose:** Build, query, and inspect a lightweight knowledge graph of the project in `.planning/graphs/`. Opt-in per project. Exposed as the `/gsd-graphify` user-facing command and the `gsd-tools.cjs graphify …` programmatic verb family. Complements `/gsd-intel` (snapshot-oriented) with a graph-oriented view of nodes and edges across commands, agents, workflows, and phases.
+
+**Requirements:**
+- REQ-GRAPH-01: Opt-in via `graphify.enabled: true` in `.planning/config.json`. When disabled, `/gsd-graphify` prints an activation hint and stops without writing.
+- REQ-GRAPH-02: Subcommand surface `build`, `query <term>`, `status`, `diff`, `snapshot` on both `/gsd-graphify` and `node gsd-tools.cjs graphify …`.
+- REQ-GRAPH-03: Build runs within the configurable `graphify.build_timeout` (seconds); exceeding the timeout aborts cleanly without leaving a partial graph.
+- REQ-GRAPH-04: `graphify.cjs` falls back to `graph.links` when `graph.edges` is absent so older graph artifacts keep rendering.
+- REQ-GRAPH-05: CJS-only surface; `gsd-sdk query` does not yet register graphify handlers.
+
+**Configuration:** `graphify.enabled`, `graphify.build_timeout`
+**Reference files:** `commands/gsd/graphify.md`, `bin/lib/graphify.cjs`


### PR DESCRIPTION
## Summary

PR 2 of a stacked 5-PR docs refresh series. Closes the v1.36.0 shipped-surface gaps so the docs match the code that ships.

### Changes

**`docs/COMMANDS.md`**

- Add `/gsd-graphify` section with `build`, `query`, `status`, `diff` subcommands, the config gate (`graphify.enabled: true`), and a usage example.
- Expand `/gsd-quick` with the `--validate` flag and `list` / `status <slug>` / `resume <slug>` subcommands (sourced from `commands/gsd/quick.md:2-39,53-60`).
- Expand `/gsd-thread` with `list --open`, `list --resolved`, `close <slug>`, `status <slug>` (sourced from `commands/gsd/thread.md:3-29`).

**`docs/CLI-TOOLS.md`**

- Replace the hardcoded \"15 domain modules\" count with a pointer to the Module Architecture table (the `get-shit-done/bin/lib/` directory is authoritative).
- Add a Graphify verb-family section covering `build`, `query`, `status`, `diff`, `snapshot`, noting CJS-only surface.
- Add `Graphify` and `Learnings` rows to the Module Architecture table.

**`docs/FEATURES.md`**

- Add TOC entries for #116 TDD Pipeline Mode and #117 Knowledge Graph Integration under v1.36.0 Features.
- Add the #117 body with REQ-GRAPH-01..05 (config gate, subcommand surface, build timeout, `graph.links` fallback, CJS-only).

**`docs/CONFIGURATION.md`**

- Move `security_enforcement`, `security_asvs_level`, `security_block_on` from the root of the Full Schema into the `workflow.*` block to match `templates/config.json:10-12` and the runtime reads in `workflows/plan-phase.md`, `execute-phase.md`, `secure-phase.md`, `verify-work.md`.
- Update the Security Settings descriptive table to use the `workflow.*` prefix and add a one-sentence note about canonical location.
- Add `planning.sub_repos: []` to the Full Schema and a description row in Planning Settings.
- Add a Graphify Settings section with `graphify.enabled` and `graphify.build_timeout`.

### Note on the security_* and sub_repos validator gap

`VALID_CONFIG_KEYS` in `get-shit-done/bin/lib/config.cjs` does not currently include `workflow.security_*` or `planning.sub_repos`, so `config-set` rejects them even though the shipped template and runtime reads both use these paths. That is a pre-existing validator gap, out of scope for a docs-only PR. The proposal originally flagged the `security_*` placement as policy-sensitive, but the evidence (template + four workflow read sites) is unambiguous on location, so the docs alignment is included here. Maintainer follow-up: extend `VALID_CONFIG_KEYS` so the validator accepts these keys.

### Scope

Docs-only. No `CHANGELOG.md` touches. No localized docs. No runtime / test changes.

### Stack context

**Base:** `docs/pr1-trust-bug-hotfixes` (PR upstream #2350). This is the second in a 5-PR series — PRs 2-5 are opened against the fork because stacked bases need to live in the same repo as the PR.

1. PR 1 — trust-bug hotfixes (upstream #2350)
2. **PR 2 (this PR)** — shipped-surface catchup
3. PR 3 — inventory and model-profile truth
4. PR 4 — drift-prevention parity tests
5. PR 5 — cleanup

## Test plan

- [ ] Render `docs/COMMANDS.md`, `docs/CLI-TOOLS.md`, `docs/FEATURES.md`, `docs/CONFIGURATION.md` and spot-check new sections
- [ ] Confirm `/gsd-graphify` doc matches `commands/gsd/graphify.md` subcommand surface
- [ ] Confirm `/gsd-quick` and `/gsd-thread` doc matches `commands/gsd/quick.md` and `commands/gsd/thread.md`
- [ ] Confirm Security Settings table paths match `templates/config.json` and runtime reads in `workflows/*.md`