### PR TITLE
Hotfix publish workflow npm 11 client

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,8 +62,8 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "update_release_notes=$UPDATE_RELEASE_NOTES" >> "$GITHUB_OUTPUT"
 
-      - name: Update npm for Trusted Publishing (requires >= 11.5.1)
-        run: npm install -g npm@latest
+      - name: Verify pinned npm 11 publish client
+        run: npx npm@11.12.1 --version
 
       - name: Install dependencies
         run: npm ci
@@ -133,4 +133,4 @@ jobs:
 
       - name: Publish to npm
         if: ${{ steps.npm_version.outputs.already_published != 'true' }}
-        run: npm publish --provenance --access public
+        run: npx npm@11.12.1 publish --provenance --access public


### PR DESCRIPTION
## Summary

- replace the broken `npm install -g npm@latest` step in `publish.yml`
- verify a pinned npm 11 client with `npx npm@11.12.1 --version`
- publish with that pinned npm 11 client so trusted publishing can proceed without mutating the runner-global npm installation

## Why

The first `reflect-v1.19.5` recovery run on `main` failed before tests in `Update npm for Trusted Publishing`, with:

- `npm error Cannot find module 'promise-retry'`

This hotfix keeps the Node 22 workflow repair from PR #50, but avoids the broken global npm self-update path.
