### PR TITLE
release: v1.19.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ For upstream GSD changelog, see [GSD Changelog](https://github.com/glittercowboy
 
 ## [Unreleased]
 
+## [1.19.7] - 2026-04-20
+
+### Added
+- Phase 58 structural enforcement surfaces across release, closeout, parity, and delegation integrity: release-lag assertions, phase reconciliation, agent-archive preservation, source-vs-installed parity verification, scope-translation ledger enforcement, and gate fire-event extraction.
+- The upstream-style discuss assumptions analyzer, richer discuss-mode documentation, and related mode-aware workflow gates now ship in the forked runtime surfaces.
+
+### Changed
+- Governance state now tracks the inserted Phase 58.1 Codex update-parity work and the explicit release-boundary closeout still required after phase implementation lands.
+
+### Fixed
+- `gsdr-update` on Codex now enumerates repo-local and active global installs correctly, targets the stale scope explicitly, preserves non-default `CODEX_CONFIG_DIR`, and avoids repo-local `.codex` mirrors masking stale active installs.
+- Source-repo update execution now forces the published `get-shit-done-reflect-cc@latest` package instead of accidentally resolving the local checkout.
+
 ## [1.19.6] - 2026-04-20
 
 ### Added

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -37,7 +37,7 @@
     "always_confirm_destructive": true,
     "always_confirm_external_services": true
   },
-  "gsd_reflect_version": "1.19.6",
+  "gsd_reflect_version": "1.19.7",
   "health_check": {
     "frequency": "milestone-only",
     "stale_threshold_days": 7,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shit-done-reflect-cc",
-  "version": "1.19.6",
+  "version": "1.19.7",
   "description": "A self-improving AI coding system that learns from its mistakes. Built on GSD by TACHES.",
   "bin": {
     "get-shit-done-reflect-cc": "bin/install.js"


### PR DESCRIPTION
## Summary
- bump package version and stamped template version to `1.19.7`
- publish changelog notes for Phase 58 structural enforcement and Phase 58.1 Codex update parity
- route the release commit itself through PR + CI before tagging the merged `main` commit

## Verification
- PR #52 passed required CI before merge for the shipped 58.1 code
- this PR is release-artifacts only (`package.json`, `get-shit-done/templates/config.json`, `CHANGELOG.md`)