### PR TITLE
Phase 59.1: drop-gemini-and-opencode-from-installer-scope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ commands.html
 
 # Local test installs
 .claude/
+.gemini/
+.opencode/
 
 # Build artifacts (committed to npm, not git)
 hooks/dist/

--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-A self-improving, runtime-agnostic enhancement to the GSD (Get Shit Done) workflow system. Features a complete signal lifecycle (detect, triage, remediate, verify, recurrence check) with multi-sensor collection (artifact + git + CI sensors), confidence-weighted reflection that distills lessons from accumulated signals, and epistemic rigor (counter-evidence seeking, tiered validation) built into every stage. The automation loop is self-triggering: signal collection auto-fires after phase execution, reflection auto-triggers after configurable phase counts, health checks run at session start, and CI failures surface immediately — all governed by a 4-level automation system (manual/nudge/prompt/auto) with per-feature overrides and context-aware deferral. Includes a persistent knowledge base (project-local at `.planning/knowledge/` with `~/.gsd/knowledge/` fallback), a structured spike/experiment workflow for resolving design uncertainty empirically, and knowledge surfacing that retrieves relevant lessons during research and planning. Signal-plan linkage closes the loop: plans declare which signals they fix, completion auto-updates remediation status, and passive verification confirms fixes after configurable phase windows. Plan intelligence validates plans semantically before execution (tool/config/dir/signal reference checking). Health scoring provides two-dimensional assessment (infrastructure + workflow) with traffic-light statusline display and rogue file detection. Supports 4 runtimes (Claude Code, OpenCode, Gemini CLI, OpenAI Codex CLI) with cross-runtime pause/resume, shared state, per-runtime capability detection, and GSDR namespace co-installation alongside upstream GSD. Includes a structured backlog system (per-project + global), a declarative feature manifest for config-driven upgrades, and a shared agent protocol for maintainable agent specs. Synchronized with upstream GSD v1.18.0 including the gsd-tools CLI, thin orchestrator architecture, and 11 bug fixes. Includes production tooling: workspace health checks with probe-based architecture, version migration, DevOps context capture, and installer hardening with safeFs error reporting.
+A self-improving, runtime-agnostic enhancement to the GSD (Get Shit Done) workflow system. Features a complete signal lifecycle (detect, triage, remediate, verify, recurrence check) with multi-sensor collection (artifact + git + CI sensors), confidence-weighted reflection that distills lessons from accumulated signals, and epistemic rigor (counter-evidence seeking, tiered validation) built into every stage. The automation loop is self-triggering: signal collection auto-fires after phase execution, reflection auto-triggers after configurable phase counts, health checks run at session start, and CI failures surface immediately — all governed by a 4-level automation system (manual/nudge/prompt/auto) with per-feature overrides and context-aware deferral. Includes a persistent knowledge base (project-local at `.planning/knowledge/` with `~/.gsd/knowledge/` fallback), a structured spike/experiment workflow for resolving design uncertainty empirically, and knowledge surfacing that retrieves relevant lessons during research and planning. Signal-plan linkage closes the loop: plans declare which signals they fix, completion auto-updates remediation status, and passive verification confirms fixes after configurable phase windows. Plan intelligence validates plans semantically before execution (tool/config/dir/signal reference checking). Health scoring provides two-dimensional assessment (infrastructure + workflow) with traffic-light statusline display and rogue file detection. The actively supported runtimes are Claude Code and OpenAI Codex CLI, with shared state, per-runtime capability detection, and GSDR namespace co-installation alongside upstream GSD. Includes a structured backlog system (per-project + global), a declarative feature manifest for config-driven upgrades, and a shared agent protocol for maintainable agent specs. Synchronized with upstream GSD v1.18.0 including the gsd-tools CLI, thin orchestrator architecture, and 11 bug fixes. Includes production tooling: workspace health checks with probe-based architecture, version migration, DevOps context capture, and installer hardening with safeFs error reporting.
 
 ## Core Value
 
@@ -20,7 +20,7 @@ See `.planning/deliberations/measurement-infrastructure-epistemic-foundations.md
 - ✓ Parallel research, planning, and execution workflows — existing
 - ✓ State management via .planning/ directory (STATE.md, ROADMAP.md, config.json) — existing
 - ✓ Atomic commits per task with session recovery — existing
-- ✓ Multi-runtime support (Claude Code, OpenCode, Gemini CLI) — existing
+- ✓ Active runtime support for Claude Code and OpenAI Codex CLI — existing
 - ✓ Checkpoint-based deviation handling — existing
 - ✓ Codebase mapping for brownfield projects — existing
 - ✓ Signal tracking: automatic detection of workflow deviations — v1.12
@@ -208,7 +208,7 @@ Test suite: 628 tests (419 vitest + 191 upstream node:test + 18 fork node:test),
 - v1.18 adopted upstream's modular architecture and 10 features with deep integration
 - GSDR namespace co-installation enables side-by-side with upstream GSD
 - Tracked-modifications strategy with FORK-DIVERGENCES.md documenting per-module merge stances (16 modules)
-- 4 runtimes supported: Claude Code, OpenCode, Gemini CLI, OpenAI Codex CLI
+- Supported installer/runtime contract narrowed to Claude Code and OpenAI Codex CLI; deprecated Gemini/OpenCode surfaces remain available only as historical reference where explicitly marked
 - Durable sync policy formalized: trigger-based cadence, baseline-freeze rules, 5-class gap taxonomy, integration depth standard
 - Outstanding upstream work prioritized: security hardening (P1), new modules (P2), test infrastructure (P3)
 - Fork-upstream relationship characterized as complementary divergence — shared substrate, different higher-level concerns
@@ -217,7 +217,7 @@ Test suite: 628 tests (419 vitest + 191 upstream node:test + 18 fork node:test),
 
 - **Architecture**: Must follow existing GSD patterns (Markdown commands, XML workflows, agent specs) — no new runtime dependencies
 - **Storage**: Knowledge base must be file-based (no databases) to maintain GSD's zero-dependency philosophy
-- **Compatibility**: Must work across Claude Code, OpenCode, Gemini CLI, and OpenAI Codex CLI runtimes
+- **Compatibility**: Must work across the actively supported Claude Code and OpenAI Codex CLI runtimes
 - **Context**: Signal logging and knowledge base queries must not bloat agent context windows — lazy loading is critical
 - **Non-invasive**: Signal tracking must not slow down or interrupt normal workflow execution
 - **Fork maintenance**: This is a fork of GSD upstream — divergences from upstream files are tracked in FORK-DIVERGENCES.md with explicit category, rationale, and merge stance. See FORK-STRATEGY.md for the full maintenance approach

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -393,10 +393,10 @@ Plans:
 **Goal:** [Urgent work - to be planned]
 **Requirements**: TBD
 **Depends on:** Phase 59
-**Plans:** 0 plans
+**Plans:** 3/3 plans complete
 
 Plans:
-- [ ] TBD (run /gsd-plan-phase 59.1 to break down)
+- [x] TBD (run /gsd-plan-phase 59.1 to break down) (completed 2026-04-21)
 
 ### Phase 60: Sensor Pipeline & Codex Parity
 **Goal**: Log sensor and patch sensor are operational across Claude Code and Codex CLI, with automated parity verification after installation

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,8 +3,8 @@ gsd_state_version: 1.0
 milestone: v1.20
 milestone_name: Signal Infrastructure & Epistemic Rigor
 status: verifying
-stopped_at: Completed 59.1-03-PLAN.md
-last_updated: "2026-04-21T09:02:15.901Z"
+stopped_at: Reconciled phase 59.1 via GATE-10
+last_updated: "2026-04-21T09:12:37.818Z"
 last_activity: 2026-04-21
 progress:
   total_phases: 25
@@ -424,8 +424,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-21T09:02:15.894Z
-Stopped at: Completed 59.1-03-PLAN.md
+Last session: 2026-04-21T09:12:37.811Z
+Stopped at: Reconciled phase 59.1 via GATE-10
 Resume artifact: `.planning/phases/58.1-codex-update-distribution-parity/58.1-VERIFICATION.md`
 
 This session (2026-04-20):

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,12 +2,12 @@
 gsd_state_version: 1.0
 milestone: v1.20
 milestone_name: Signal Infrastructure & Epistemic Rigor
-status: verified
-stopped_at: "Phase 59 verified passed (7/7 must-haves against codebase); ready for PR on gsd/phase-59-kb-query-lifecycle-wiring-and-surfacing"
-last_updated: "2026-04-21T05:30:00Z"
+status: verifying
+stopped_at: Phase 59.1 context gathered
+last_updated: "2026-04-21T07:16:42.002Z"
 last_activity: 2026-04-21
 progress:
-  total_phases: 24
+  total_phases: 25
   completed_phases: 16
   total_plans: 78
   completed_plans: 78
@@ -415,8 +415,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-21T05:14:26.000Z
-Stopped at: Completed 59-05-PLAN.md (Wave 4: knowledge-surfacing rewrite + 59-DEFERRALS ledger + cross-runtime kb parity; Phase 59 closure ready for verifier)
+Last session: 2026-04-21T07:16:41.995Z
+Stopped at: Phase 59.1 context gathered
 Resume artifact: `.planning/phases/58.1-codex-update-distribution-parity/58.1-VERIFICATION.md`
 
 This session (2026-04-20):

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.20
 milestone_name: Signal Infrastructure & Epistemic Rigor
 status: verifying
-stopped_at: Phase 59.1 plan verified
-last_updated: "2026-04-21T08:07:24.091Z"
+stopped_at: Completed 59.1-01-PLAN.md
+last_updated: "2026-04-21T08:42:17.355Z"
 last_activity: 2026-04-21
 progress:
   total_phases: 25
   completed_phases: 16
   total_plans: 81
-  completed_plans: 78
-  percent: 96
+  completed_plans: 79
+  percent: 98
 ---
 
 # Project State
@@ -27,7 +27,7 @@ See: .planning/PROJECT.md (updated 2026-04-08)
 
 Phase: 59 of 64 — Execution complete on `gsd/phase-59-kb-query-lifecycle-wiring-and-surfacing`
 Plan: 5 of 5 complete
-Status: Verifier passed — ready for PR
+Status: Phase complete — ready for verification
 
 ### Recent Phases
 
@@ -311,6 +311,8 @@ Recent decisions affecting current work:
 - [Phase 59]: knowledge-surfacing.md v1.0.0->v2.0.0 rewrite retires lesson-only grep-through-index path; SQLite-first signals+spikes+reflections triad with structural inbound-edge fetch via kb link show --inbound
 - [Phase 59]: 59-DEFERRALS.md enumerates KB-12..KB-17 in GATE-09 ledger-consumable form; REQUIREMENTS.md adds footer cross-reference (no content duplication); KB-04b..KB-08 flipped [x] with closed-by Phase 59 Plan N annotations
 - [Phase 59]: Cross-runtime parity integration test: sha256 equality for 5 kb* lib files + knowledge-surfacing.md across .claude and .codex; JSON shape parity for all new kb verbs. Phase 58.1 DC-4 held across Phase 59
+- [Phase 59.1]: Installer runtime support authority now lives in get-shit-done/bin/lib/runtime-support.cjs, and bin/install.js plus installer tests consume that shared Claude/Codex-only surface directly.
+- [Phase 59.1]: Legacy installer flags --gemini, --opencode, and --both now fail fast with migration guidance instead of remapping to supported runtimes.
 
 ### Roadmap Evolution
 
@@ -397,6 +399,7 @@ Recent decisions affecting current work:
 | Phase 59 P04 | 13min | 2 tasks | 9 files |
 | Phase 59 P04 | 13min | 2 tasks | 9 files |
 | Phase 59 P05 | 8min | 2 tasks | 6 files |
+| Phase 59.1 P01 | 8min | 2 tasks | 3 files |
 
 ### Key Artifacts
 
@@ -415,8 +418,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-21T08:07:24.082Z
-Stopped at: Phase 59.1 plan verified
+Last session: 2026-04-21T08:42:17.346Z
+Stopped at: Completed 59.1-01-PLAN.md
 Resume artifact: `.planning/phases/58.1-codex-update-distribution-parity/58.1-VERIFICATION.md`
 
 This session (2026-04-20):

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.20
 milestone_name: Signal Infrastructure & Epistemic Rigor
 status: verifying
-stopped_at: Phase 59.1 context gathered
-last_updated: "2026-04-21T07:16:42.002Z"
+stopped_at: Phase 59.1 plan verified
+last_updated: "2026-04-21T08:07:24.091Z"
 last_activity: 2026-04-21
 progress:
   total_phases: 25
   completed_phases: 16
-  total_plans: 78
+  total_plans: 81
   completed_plans: 78
-  percent: 100
+  percent: 96
 ---
 
 # Project State
@@ -415,8 +415,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-21T07:16:41.995Z
-Stopped at: Phase 59.1 context gathered
+Last session: 2026-04-21T08:07:24.082Z
+Stopped at: Phase 59.1 plan verified
 Resume artifact: `.planning/phases/58.1-codex-update-distribution-parity/58.1-VERIFICATION.md`
 
 This session (2026-04-20):

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -4,7 +4,7 @@ milestone: v1.20
 milestone_name: Signal Infrastructure & Epistemic Rigor
 status: verifying
 stopped_at: Reconciled phase 59.1 via GATE-10
-last_updated: "2026-04-21T09:12:37.818Z"
+last_updated: "2026-04-21T09:13:51.871Z"
 last_activity: 2026-04-21
 progress:
   total_phases: 25
@@ -424,7 +424,7 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-21T09:12:37.811Z
+Last session: 2026-04-21T09:13:51.864Z
 Stopped at: Reconciled phase 59.1 via GATE-10
 Resume artifact: `.planning/phases/58.1-codex-update-distribution-parity/58.1-VERIFICATION.md`
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.20
 milestone_name: Signal Infrastructure & Epistemic Rigor
 status: verifying
-stopped_at: Completed 59.1-02-PLAN.md
-last_updated: "2026-04-21T08:56:09.215Z"
+stopped_at: Completed 59.1-03-PLAN.md
+last_updated: "2026-04-21T09:02:15.901Z"
 last_activity: 2026-04-21
 progress:
   total_phases: 25
-  completed_phases: 16
+  completed_phases: 17
   total_plans: 81
-  completed_plans: 80
-  percent: 99
+  completed_plans: 81
+  percent: 100
 ---
 
 # Project State
@@ -21,12 +21,12 @@ progress:
 See: .planning/PROJECT.md (updated 2026-04-08)
 
 **Core value:** The system never makes the same mistake twice -- signals capture what went wrong, spikes resolve uncertainty empirically, and the knowledge base surfaces relevant lessons before they're needed.
-**Current focus:** v1.20 Phase 59 (KB Query, Lifecycle Wiring & Surfacing) shipped on branch `gsd/phase-59-kb-query-lifecycle-wiring-and-surfacing`. Verifier passed 7/7 ROADMAP must-haves against the codebase (763/763 tests, cross-runtime sha256 parity confirmed). `kb query`/`search`/`link show` live on FTS5 substrate, `kb transition` closes the lifecycle wiring loop (KB-07), `kb health` four-check watchdog is online, `knowledge-surfacing.md` rewritten SQLite-first, and KB-12..KB-17 enumerated as GATE-09-consumable deferrals in `59-DEFERRALS.md`. Ready for PR.
+**Current focus:** v1.20 Phase 59.1 (Drop Gemini and OpenCode from installer scope) completed on branch `gsd/phase-59.1-drop-gemini-and-opencode-from-installer-scope`. README install guidance, live project framing, the capability matrix, and the Unreleased changelog now all mirror the Claude/Codex-only installer contract. Ready for verification.
 
 ## Current Position
 
-Phase: 59 of 64 — Execution complete on `gsd/phase-59-kb-query-lifecycle-wiring-and-surfacing`
-Plan: 5 of 5 complete
+Phase: 59.1 of 64 — Execution complete on `gsd/phase-59.1-drop-gemini-and-opencode-from-installer-scope`
+Plan: 3 of 3 complete
 Status: Phase complete — ready for verification
 
 ### Recent Phases
@@ -36,13 +36,13 @@ Status: Phase complete — ready for verification
 
 Last activity: 2026-04-21
 
-Progress: [██████████] 99%
+Progress: [██████████] 100%
 
 ## Performance Metrics
 
 **v1.20 Current:**
 
-- Plans completed: 38
+- Plans completed: 39
 - 55-01: 1min, 2 tasks, 5 files
 - 55-02: 9min, 2 tasks, 5 files
 - 55-03: 9min, 2 tasks, 6 files
@@ -315,6 +315,8 @@ Recent decisions affecting current work:
 - [Phase 59.1]: Legacy installer flags --gemini, --opencode, and --both now fail fast with migration guidance instead of remapping to supported runtimes.
 - [Phase 59.1]: Integration suites now consume SUPPORTED_INSTALLER_RUNTIMES instead of local four-runtime constants.
 - [Phase 59.1]: Shared-KB --all fixtures now assert Claude/Codex presence and Gemini/OpenCode absence before running KB checks.
+- [Phase 59.1]: README and PROJECT present-tense runtime wording now advertise only the supported Claude Code and Codex CLI installer contract.
+- [Phase 59.1]: The capability matrix preserves deprecated Gemini/OpenCode columns for reference, but its support language and release notes now reflect that installer access is limited to Claude/Codex and legacy flags fail with migration guidance.
 
 ### Roadmap Evolution
 
@@ -403,6 +405,7 @@ Recent decisions affecting current work:
 | Phase 59 P05 | 8min | 2 tasks | 6 files |
 | Phase 59.1 P01 | 8min | 2 tasks | 3 files |
 | Phase 59.1 P02 | 10min | 2 tasks | 3 files |
+| Phase 59.1 P03 | 7min | 2 tasks | 4 files |
 
 ### Key Artifacts
 
@@ -421,8 +424,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-21T08:56:09.207Z
-Stopped at: Completed 59.1-02-PLAN.md
+Last session: 2026-04-21T09:02:15.894Z
+Stopped at: Completed 59.1-03-PLAN.md
 Resume artifact: `.planning/phases/58.1-codex-update-distribution-parity/58.1-VERIFICATION.md`
 
 This session (2026-04-20):

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,15 +3,15 @@ gsd_state_version: 1.0
 milestone: v1.20
 milestone_name: Signal Infrastructure & Epistemic Rigor
 status: verifying
-stopped_at: Completed 59.1-01-PLAN.md
-last_updated: "2026-04-21T08:42:17.355Z"
+stopped_at: Completed 59.1-02-PLAN.md
+last_updated: "2026-04-21T08:56:09.215Z"
 last_activity: 2026-04-21
 progress:
   total_phases: 25
   completed_phases: 16
   total_plans: 81
-  completed_plans: 79
-  percent: 98
+  completed_plans: 80
+  percent: 99
 ---
 
 # Project State
@@ -313,6 +313,8 @@ Recent decisions affecting current work:
 - [Phase 59]: Cross-runtime parity integration test: sha256 equality for 5 kb* lib files + knowledge-surfacing.md across .claude and .codex; JSON shape parity for all new kb verbs. Phase 58.1 DC-4 held across Phase 59
 - [Phase 59.1]: Installer runtime support authority now lives in get-shit-done/bin/lib/runtime-support.cjs, and bin/install.js plus installer tests consume that shared Claude/Codex-only surface directly.
 - [Phase 59.1]: Legacy installer flags --gemini, --opencode, and --both now fail fast with migration guidance instead of remapping to supported runtimes.
+- [Phase 59.1]: Integration suites now consume SUPPORTED_INSTALLER_RUNTIMES instead of local four-runtime constants.
+- [Phase 59.1]: Shared-KB --all fixtures now assert Claude/Codex presence and Gemini/OpenCode absence before running KB checks.
 
 ### Roadmap Evolution
 
@@ -400,6 +402,7 @@ Recent decisions affecting current work:
 | Phase 59 P04 | 13min | 2 tasks | 9 files |
 | Phase 59 P05 | 8min | 2 tasks | 6 files |
 | Phase 59.1 P01 | 8min | 2 tasks | 3 files |
+| Phase 59.1 P02 | 10min | 2 tasks | 3 files |
 
 ### Key Artifacts
 
@@ -418,8 +421,8 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-04-21T08:42:17.346Z
-Stopped at: Completed 59.1-01-PLAN.md
+Last session: 2026-04-21T08:56:09.207Z
+Stopped at: Completed 59.1-02-PLAN.md
 Resume artifact: `.planning/phases/58.1-codex-update-distribution-parity/58.1-VERIFICATION.md`
 
 This session (2026-04-20):

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -50,7 +50,7 @@
     "stats": {
       "signal_collection": {
         "fires": 0,
-        "skips": 16,
+        "skips": 17,
         "last_triggered": null,
         "last_skip_reason": "level-1",
         "last_run_status": "skipped"
@@ -79,7 +79,7 @@
       },
       "reflection": {
         "fires": 0,
-        "skips": 9,
+        "skips": 10,
         "last_triggered": null,
         "last_skip_reason": "disabled",
         "last_run_status": "skipped"
@@ -97,7 +97,7 @@
       "auto_reflect": false,
       "threshold_phases": 3,
       "min_signals": 5,
-      "phases_since_last_reflect": 12,
+      "phases_since_last_reflect": 13,
       "last_reflect_at": "2026-03-07T05:46:29.846Z"
     },
     "level": 1,

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-PLAN.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-PLAN.md
@@ -1,0 +1,160 @@
+---
+phase: 59.1-drop-gemini-and-opencode-from-installer-scope
+plan: "01"
+signature:
+  role: planner
+  harness: codex-cli
+  platform: codex
+  vendor: openai
+  model: gpt-5
+  reasoning_effort: not_available
+  profile: quality
+  gsd_version: 1.19.6+dev
+  generated_at: "2026-04-21T07:46:17Z"
+  session_id: "019daefc-cb6e-7ab3-b07c-d4879132df4c"
+  provenance_status:
+    role: derived
+    harness: derived
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: derived
+    reasoning_effort: not_available
+    profile: derived
+    gsd_version: derived
+    generated_at: exposed
+    session_id: exposed
+  provenance_source:
+    role: artifact_role
+    harness: runtime_context
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: developer_instruction
+    reasoning_effort: env:CODEX_REASONING_EFFORT_unset
+    profile: config:model_profile
+    gsd_version: config:gsd_reflect_version
+    generated_at: writer_clock
+    session_id: env:CODEX_THREAD_ID
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - get-shit-done/bin/lib/runtime-support.cjs
+  - bin/install.js
+  - tests/unit/install.test.js
+autonomous: true
+user_setup: []
+must_haves:
+  truths:
+    - "Installer runtime support is declared once in a side-effect-free source helper consumed by `bin/install.js` and the fast regression surface, satisfying RR-5's shared-authority assumption instead of leaving four-runtime arrays duplicated in code and tests."
+    - "`bin/install.js` no longer treats Gemini/OpenCode as supported install targets: `--all` expands to Claude Code + Codex CLI only, the interactive chooser only offers supported runtimes, and `--gemini`, `--opencode`, and legacy installer `--both` fail fast with explicit migration guidance."
+    - "Gemini/OpenCode installer-specific converters, path resolvers, tool-name maps, and exports stop acting as live authority surfaces; the source no longer advertises those runtimes as installable by inertia."
+    - "Targeted unit coverage proves the helper/installer invariant and the unsupported-runtime behavior with real subprocess execution, directly addressing `sig-2026-04-21-installer-advertises-gemini-opencode-unsupported`."
+  artifacts:
+    - path: "get-shit-done/bin/lib/runtime-support.cjs"
+      provides: "Canonical supported-installer-runtime declaration and unsupported-runtime messaging helpers"
+      contains: "SUPPORTED_INSTALLER_RUNTIMES"
+    - path: "bin/install.js"
+      provides: "Installer runtime parsing/help/chooser behavior derived from the shared authority instead of four-runtime arrays"
+      contains: "SUPPORTED_INSTALLER_RUNTIMES"
+    - path: "tests/unit/install.test.js"
+      provides: "Fast invariant and subprocess coverage for supported-only `--all` and unsupported legacy runtime flags"
+      contains: "unsupported runtime"
+  key_links:
+    - from: "get-shit-done/bin/lib/runtime-support.cjs"
+      to: "bin/install.js"
+      via: "installer imports shared supported-runtime authority for flag validation, `--all`, and runtime menu construction"
+      pattern: "SUPPORTED_INSTALLER_RUNTIMES|formatUnsupportedRuntimeMessage"
+    - from: "tests/unit/install.test.js"
+      to: "get-shit-done/bin/lib/runtime-support.cjs"
+      via: "unit tests import the same helper the installer uses so runtime-scope drift fails mechanically"
+      pattern: "SUPPORTED_INSTALLER_RUNTIMES|expandInstallerRuntimeSelection"
+---
+
+<objective>
+Create the installer-side authority seam for Phase 59.1: one canonical supported-runtime declaration, installer behavior derived from it, and unit-level regressions that make the two-runtime scope mechanically enforceable.
+
+Purpose: This is the root-cause fix for the active installer drift signal. Without a shared source authority, every later docs/test update can regress back to the old four-runtime contract.
+Output: A side-effect-free runtime-support helper, a supported-only installer surface, and focused unit regressions.
+</objective>
+
+<execution_context>
+@./.codex/get-shit-done-reflect/workflows/execute-plan.md
+@./.codex/get-shit-done-reflect/templates/summary-standard.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-RESEARCH.md
+@AGENTS.md
+@bin/install.js
+@get-shit-done/bin/lib/update-target.cjs
+@tests/unit/install.test.js
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Create the canonical installer-runtime authority and rewire `bin/install.js` to it</name>
+  <files>get-shit-done/bin/lib/runtime-support.cjs, bin/install.js</files>
+  <action>Create a side-effect-free helper at `get-shit-done/bin/lib/runtime-support.cjs` that is the single source authority for installer scope. Export at minimum: the supported installer runtime list (`claude`, `codex`), the explicitly unsupported legacy installer targets (`opencode`, `gemini`, legacy installer `both`), a helper that expands installer selection for `--all`, and one formatter/helper for the unsupported-runtime error text. Follow RR-5 exactly: docs mirror this authority later, but code and tests consume it directly.
+
+Then rewire `bin/install.js` to derive its runtime-support behavior from that helper instead of inline four-runtime arrays and booleans. This task addresses signal `sig-2026-04-21-installer-advertises-gemini-opencode-unsupported`: the installer itself still exposes unsupported runtimes as first-class targets. Concrete scope:
+
+- Replace the current four-runtime `--all` expansion with the supported-only set from the helper.
+- Remove Gemini/OpenCode from the interactive runtime chooser; preserve Claude/Codex plus an `All supported runtimes` path.
+- Rewrite installer help/examples inside `bin/install.js` so unsupported flags are no longer advertised as valid install choices.
+- Explicitly reject `--gemini`, `--opencode`, and legacy installer `--both` with a non-zero exit and migration guidance. Do not silently map them to Claude/Codex.
+- Preserve existing prompt-vs-flag behavior for installs that provide no explicit runtime flags; do not invent a new silent default if the current flow prompts.
+
+Strip Gemini/OpenCode installer-only machinery from `bin/install.js` while keeping the phase tight:
+
+- Remove now-dead OpenCode/Gemini converter helpers, path resolvers, tool-name maps, runtime-specific copy branches, and `module.exports` entries if they are no longer reachable once installer support is narrowed.
+- Do not touch unrelated Codex/Claude behavior, KB paths, hook wiring, or non-installer CLI surfaces.
+- Do not retain targeted Gemini/OpenCode uninstall flags as hidden support. If migration guidance needs cleanup instructions, surface the legacy directories in the unsupported-runtime message rather than keeping the old runtime branches alive.
+
+Use `get-shit-done/bin/lib/update-target.cjs` as the pattern reference for a pure, importable runtime helper. Do not export authority from `bin/install.js` itself.</action>
+  <verify>`node -e "const s=require('./get-shit-done/bin/lib/runtime-support.cjs'); if (JSON.stringify(s.SUPPORTED_INSTALLER_RUNTIMES)!=='[\"claude\",\"codex\"]') process.exit(1)"` exits 0. `node bin/install.js --help` shows Claude/Codex-only installer options and supported-only `--all`. A temp-HOME smoke run `node bin/install.js --gemini --global` exits non-zero with an unsupported-runtime message instead of creating a runtime directory.</verify>
+  <done>The repo has one canonical installer-runtime authority; `bin/install.js` derives supported scope from it; unsupported Gemini/OpenCode installer flags fail explicitly; no Gemini/OpenCode installer support seams remain live by inertia.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Replace four-runtime unit coverage with supported-only invariants and unsupported-flag smoke tests</name>
+  <files>tests/unit/install.test.js</files>
+  <action>Rewrite the installer unit suite to match the narrowed support surface from Task 1.
+
+Specific expectations:
+
+- Stop importing any removed Gemini/OpenCode converter/path helpers from `bin/install.js`.
+- Add a fast invariant test that imports `get-shit-done/bin/lib/runtime-support.cjs` and asserts the installer helper's supported list is the same authority used by `--all`.
+- Add subprocess smoke coverage proving `--gemini`, `--opencode`, and legacy installer `--both` exit non-zero with guidance.
+- Replace the old `--all` expectations that asserted four runtimes with supported-only assertions: after `--all --global`, `.claude/` and `.codex/` exist, while `.gemini/` and OpenCode runtime outputs do not.
+- Delete or replace OpenCode/Gemini unit sections that only exist to validate dead installer conversion behavior. Do not leave those suites behind as if they still describe supported runtime behavior.
+
+Keep the rest of the installer unit suite intact where it still covers Claude/Codex or generic installer behavior. This task should narrow, not rewrite, the whole file.</action>
+  <verify>`npx vitest run tests/unit/install.test.js` passes. A targeted smoke run in a temp HOME proves `node bin/install.js --all --global` creates only `.claude` and `.codex`, and `node bin/install.js --both --global` exits non-zero with guidance.</verify>
+  <done>`tests/unit/install.test.js` enforces the supported-only installer contract and no longer preserves Gemini/OpenCode as first-class install-test targets.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `get-shit-done/bin/lib/runtime-support.cjs` exists and is side-effect free.
+- `bin/install.js` no longer advertises or expands Gemini/OpenCode as supported install targets.
+- `npx vitest run tests/unit/install.test.js` passes.
+- Unsupported runtime flags fail explicitly instead of silently installing or remapping.
+</verification>
+
+<success_criteria>
+- The active installer drift now has one canonical code authority instead of duplicated four-runtime arrays.
+- `--all` means supported runtimes only.
+- Unsupported Gemini/OpenCode installer behavior is explicit and non-successful.
+- Unit regressions make future scope drift fail mechanically.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-SUMMARY.md`
+</output>

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-SUMMARY.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-SUMMARY.md
@@ -1,0 +1,115 @@
+---
+phase: 59.1-drop-gemini-and-opencode-from-installer-scope
+plan: "01"
+signature:
+  role: executor
+  harness: codex-cli
+  platform: codex
+  vendor: openai
+  model: gpt-5
+  reasoning_effort: not_available
+  profile: quality
+  gsd_version: 1.19.6+dev
+  generated_at: "2026-04-21T08:40:24Z"
+  session_id: "019daf1e-dbfc-7173-96df-724001e16fd2"
+  provenance_status:
+    role: derived
+    harness: derived
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: derived
+    reasoning_effort: not_available
+    profile: derived
+    gsd_version: derived
+    generated_at: exposed
+    session_id: exposed
+  provenance_source:
+    role: artifact_role
+    harness: runtime_context
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: developer_instruction
+    reasoning_effort: env:CODEX_REASONING_EFFORT_unset
+    profile: config:model_profile
+    gsd_version: config:gsd_reflect_version
+    generated_at: writer_clock
+    session_id: env:CODEX_THREAD_ID
+context_used_pct: 34
+subsystem: installer
+tags: [installer, claude, codex, gemini, opencode, runtime-support, phase-59.1]
+requires:
+  - phase: 59-kb-query-lifecycle-wiring-and-surfacing
+    provides: "Verified v1.20 baseline and the live installer/test substrate this scope-tightening change builds on"
+provides:
+  - "Canonical installer runtime authority in `get-shit-done/bin/lib/runtime-support.cjs` with supported-only expansion and unsupported-runtime guidance"
+  - "`bin/install.js` now derives `--all`, help text, and interactive runtime choices from the shared Claude/Codex-only authority"
+  - "Installer unit coverage now locks `--all` to Claude/Codex and proves `--gemini`, `--opencode`, and `--both` fail non-zero with guidance"
+affects: [installer, tests, phase-59.1, runtime-parity]
+tech-stack:
+  added: []
+  patterns:
+    - "Pure shared authority helper for installer runtime scope"
+    - "Fail-fast rejection for unsupported legacy installer flags"
+    - "Shared invariant + subprocess smoke coverage for CLI scope enforcement"
+key-files:
+  created:
+    - "get-shit-done/bin/lib/runtime-support.cjs"
+  modified:
+    - "bin/install.js"
+    - "tests/unit/install.test.js"
+key-decisions:
+  - "Installer runtime scope authority lives in `get-shit-done/bin/lib/runtime-support.cjs`, not in duplicated arrays inside `bin/install.js` or tests."
+  - "Legacy installer flags `--gemini`, `--opencode`, and `--both` now fail explicitly with migration guidance instead of remapping to supported runtimes."
+patterns-established:
+  - "Supported-only installer scope: `--all`, help text, and interactive selection all consume one shared authority surface."
+duration: 8min
+completed: 2026-04-21
+---
+
+# Phase 59.1 Plan 01: Drop Gemini And OpenCode From Installer Scope Summary
+
+**Installer runtime scope now ships from one Claude/Codex-only helper, with Gemini/OpenCode flags rejected explicitly and tests locking the supported-only contract in place.**
+
+## Performance
+- **Duration:** 8min
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+- Added `get-shit-done/bin/lib/runtime-support.cjs` as the canonical installer-runtime authority, with supported runtime expansion and unsupported-runtime messaging kept side-effect free.
+- Rewired `bin/install.js` so `--all`, help output, and the interactive runtime chooser expose only Claude Code, Codex CLI, and an all-supported path.
+- Removed live Gemini/OpenCode installer seams from `bin/install.js`, replacing them with explicit non-zero failures and migration guidance for legacy flags.
+- Reworked `tests/unit/install.test.js` to import the shared authority, assert supported-only `--all`, and smoke-test `--gemini`, `--opencode`, and `--both` rejection paths.
+
+## Task Commits
+1. **Task 1: Create the canonical installer-runtime authority and rewire `bin/install.js` to it** - `3bd1fb16`
+2. **Task 2: Replace four-runtime unit coverage with supported-only invariants and unsupported-flag smoke tests** - `c5d5b746`
+
+## Files Created/Modified
+- `get-shit-done/bin/lib/runtime-support.cjs` - Canonical supported-installer-runtime metadata and helpers for supported expansion plus unsupported-runtime guidance.
+- `bin/install.js` - Installer flag parsing, help text, interactive choices, and runtime handling now derive from the shared supported-only authority.
+- `tests/unit/install.test.js` - Installer regression suite now enforces Claude/Codex-only `--all` behavior and explicit legacy-flag failure semantics.
+
+## Decisions & Deviations
+### Key decisions
+
+- Installer runtime scope authority moved into a pure shared helper so code and tests consume the same surface directly.
+- Unsupported legacy runtime flags now fail fast instead of silently remapping, preserving a narrow installer support contract.
+
+### Deviations from plan
+
+- **[Rule 1 - Bug] Restored Codex tool-map binding during Task 2 verification.** The supported-runtime refactor left `claudeToCodexTools` commented out in `bin/install.js`, which surfaced as a `ReferenceError` in the updated installer test run. I restored the binding and kept the `resolve_model_ids` write in the Codex branch before the early return. Files modified: `bin/install.js`. Commit: `c5d5b746`.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+Follow-on installer docs, runtime parity checks, and any remaining Phase 59.1 support-surface work can now consume one canonical installer-runtime authority instead of reintroducing four-runtime drift through duplicated arrays or stale tests.
+
+## Self-Check: PASSED
+
+- `FOUND: .planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-SUMMARY.md`
+- `FOUND: 3bd1fb16`
+- `FOUND: c5d5b746`

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-PLAN.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-PLAN.md
@@ -1,0 +1,152 @@
+---
+phase: 59.1-drop-gemini-and-opencode-from-installer-scope
+plan: "02"
+signature:
+  role: planner
+  harness: codex-cli
+  platform: codex
+  vendor: openai
+  model: gpt-5
+  reasoning_effort: not_available
+  profile: quality
+  gsd_version: 1.19.6+dev
+  generated_at: "2026-04-21T07:46:17Z"
+  session_id: "019daefc-cb6e-7ab3-b07c-d4879132df4c"
+  provenance_status:
+    role: derived
+    harness: derived
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: derived
+    reasoning_effort: not_available
+    profile: derived
+    gsd_version: derived
+    generated_at: exposed
+    session_id: exposed
+  provenance_source:
+    role: artifact_role
+    harness: runtime_context
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: developer_instruction
+    reasoning_effort: env:CODEX_REASONING_EFFORT_unset
+    profile: config:model_profile
+    gsd_version: config:gsd_reflect_version
+    generated_at: writer_clock
+    session_id: env:CODEX_THREAD_ID
+type: execute
+wave: 2
+depends_on:
+  - "01"
+files_modified:
+  - .gitignore
+  - tests/integration/multi-runtime.test.js
+  - tests/integration/cross-runtime-kb.test.js
+autonomous: true
+user_setup: []
+must_haves:
+  truths:
+    - "Integration/regression surfaces now treat the supported installer runtime set as Claude Code + Codex CLI only; no integration suite still encodes OpenCode/Gemini as supported `--all` outputs."
+    - "At least one mechanical regression imports or otherwise directly consumes the same source authority introduced in Plan 01, so installer-target scope and regression expectations cannot drift independently."
+    - "`.gitignore` defensively ignores repo-local `.gemini/` and `.opencode/` byproducts so local verification of older installs does not leave noisy runtime artifacts behind."
+    - "The shared-KB and multi-runtime smoke suites still verify supported runtimes honestly after the narrowing: `--all` creates only supported runtime layouts, and unsupported runtime directories are explicitly absent."
+  artifacts:
+    - path: ".gitignore"
+      provides: "Defensive ignore coverage for unsupported runtime byproducts"
+      contains: ".gemini/"
+    - path: "tests/integration/multi-runtime.test.js"
+      provides: "Supported-only installer layout and parity regression coverage"
+      contains: "SUPPORTED_INSTALLER_RUNTIMES"
+    - path: "tests/integration/cross-runtime-kb.test.js"
+      provides: "Supported-only `--all` shared-KB regression coverage"
+      contains: "--all"
+  key_links:
+    - from: "tests/integration/multi-runtime.test.js"
+      to: "get-shit-done/bin/lib/runtime-support.cjs"
+      via: "integration suite imports shared installer-runtime authority rather than preserving a four-runtime constant"
+      pattern: "SUPPORTED_INSTALLER_RUNTIMES"
+    - from: "tests/integration/cross-runtime-kb.test.js"
+      to: "bin/install.js"
+      via: "shared-KB tests run `bin/install.js --all --global` and assert supported-only runtime outputs"
+      pattern: "--all --global"
+---
+
+<objective>
+Re-scope the installer regression surfaces and local byproduct hygiene around the new authority from Plan 01.
+
+Purpose: Phase 59.1 is not complete when only the installer code changes; the regression layer has to stop preserving the old four-runtime worldview or the next edit will silently reintroduce it.
+Output: Supported-only integration suites plus defensive `.gitignore` coverage.
+</objective>
+
+<execution_context>
+@./.codex/get-shit-done-reflect/workflows/execute-plan.md
+@./.codex/get-shit-done-reflect/templates/summary-standard.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-RESEARCH.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-SUMMARY.md
+@.gitignore
+@tests/integration/multi-runtime.test.js
+@tests/integration/cross-runtime-kb.test.js
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Rewrite the multi-runtime integration suite around the supported-only runtime authority and add byproduct ignore coverage</name>
+  <files>.gitignore, tests/integration/multi-runtime.test.js</files>
+  <action>Update `.gitignore` to cover repo-local unsupported-runtime byproducts: add `.gemini/` and `.opencode/` alongside the existing generated-runtime ignores. This is defensive hygiene only; it does not reintroduce Gemini/OpenCode as supported runtimes.
+
+Then rewrite `tests/integration/multi-runtime.test.js` so the file no longer encodes OpenCode/Gemini as supported install targets. Concrete scope:
+
+- Import the shared authority from `get-shit-done/bin/lib/runtime-support.cjs` (or consume the exact same exported list indirectly) instead of keeping `SUPPORTED_RUNTIMES = ['claude', 'opencode', 'gemini', 'codex']`.
+- Remove or replace the OpenCode-only and Gemini-only install validation blocks that treat those runtimes as supported outputs.
+- Rewrite the `--all` sections so they assert Claude/Codex-only layouts, supported-only parity, and explicit absence of unsupported runtime directories after install.
+- Keep the installer regression honest: if a runtime-like directory outside the shared authority appears after `--all`, fail with a message that points back to the authority helper instead of silently updating a local constant.
+
+Do not widen this task into hook-capability or matrix taxonomy work. Stay on installer layout, output directories, and supported-runtime parity.</action>
+  <verify>`git check-ignore -v .gemini .opencode` reports the new ignore rules. `npx vitest run tests/integration/multi-runtime.test.js` passes with `--all` meaning supported runtimes only and no surviving four-runtime constants.</verify>
+  <done>`.gitignore` covers unsupported runtime byproducts, and `tests/integration/multi-runtime.test.js` now enforces the Claude/Codex-only contract using the same authority as the installer.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Update shared-KB `--all` coverage to supported-only semantics without touching unrelated `kb link --both` behavior</name>
+  <files>tests/integration/cross-runtime-kb.test.js</files>
+  <action>Update `tests/integration/cross-runtime-kb.test.js` so every installer-driven `--all` setup now assumes supported runtimes only.
+
+Specific expectations:
+
+- Any fixture or smoke path that shells `node bin/install.js --all --global` must assert only Claude/Codex outputs are present.
+- Add explicit absence checks for unsupported runtime directories in the temp HOME / config tree after the install fixture runs.
+- If this file keeps its own runtime list, replace it with an import of the shared installer-runtime authority from Plan 01.
+- Preserve the KB verb coverage itself; the goal is to narrow installer expectations, not to rewrite the KB assertions.
+- Do not touch `kb link show --both` assertions here. That `--both` belongs to the KB CLI surface and is unrelated to the legacy installer flag being removed.
+
+This task is where the supported-only `--all` semantics stay honest across the cross-runtime KB surface introduced in Phase 59.</action>
+  <verify>`npx vitest run tests/integration/cross-runtime-kb.test.js` passes. A targeted grep `rg -n "all 4 runtimes|SUPPORTED_RUNTIMES = \\['claude', 'opencode', 'gemini', 'codex'\\]" tests/integration/cross-runtime-kb.test.js tests/integration/multi-runtime.test.js` returns no matches.</verify>
+  <done>`tests/integration/cross-runtime-kb.test.js` no longer preserves unsupported runtime installs as part of `--all`, and the KB regression surface stays scoped to supported runtimes only.</done>
+</task>
+
+</tasks>
+
+<verification>
+- `git check-ignore -v .gemini .opencode`
+- `npx vitest run tests/integration/multi-runtime.test.js tests/integration/cross-runtime-kb.test.js`
+- No integration test still claims `--all` installs four supported runtimes.
+</verification>
+
+<success_criteria>
+- Regression surfaces use the same supported-runtime authority as installer code.
+- `.gitignore` blocks noisy unsupported-runtime byproducts.
+- `--all` integration coverage now reflects Claude/Codex-only support everywhere it matters.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-SUMMARY.md`
+</output>

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-SUMMARY.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-SUMMARY.md
@@ -1,0 +1,114 @@
+---
+phase: 59.1-drop-gemini-and-opencode-from-installer-scope
+plan: "02"
+signature:
+  role: executor
+  harness: codex-cli
+  platform: codex
+  vendor: openai
+  model: gpt-5
+  reasoning_effort: not_available
+  profile: quality
+  gsd_version: 1.19.6+dev
+  generated_at: "2026-04-21T08:54:54Z"
+  session_id: "019daf35-951e-7b12-84f9-5d06f97b528b"
+  provenance_status:
+    role: derived
+    harness: derived
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: derived
+    reasoning_effort: not_available
+    profile: derived
+    gsd_version: derived
+    generated_at: exposed
+    session_id: exposed
+  provenance_source:
+    role: artifact_role
+    harness: runtime_context
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: developer_instruction
+    reasoning_effort: env:CODEX_REASONING_EFFORT_unset
+    profile: config:model_profile
+    gsd_version: config:gsd_reflect_version
+    generated_at: writer_clock
+    session_id: env:CODEX_THREAD_ID
+context_used_pct: 41
+subsystem: installer-tests
+tags: [installer, integration-tests, claude, codex, kb, runtime-support, phase-59.1]
+requires:
+  - phase: 59.1-01
+    provides: "Shared installer runtime authority in `get-shit-done/bin/lib/runtime-support.cjs` and supported-only installer behavior"
+provides:
+  - "`.gitignore` now ignores repo-local `.gemini/` and `.opencode/` verification byproducts"
+  - "`tests/integration/multi-runtime.test.js` imports the shared supported-runtime authority and enforces Claude/Codex-only `--all` output"
+  - "`tests/integration/cross-runtime-kb.test.js` routes installer-driven `--all` fixtures through supported-only install assertions"
+affects: [installer, integration-regressions, kb-smoke, runtime-parity]
+tech-stack:
+  added: []
+  patterns:
+    - "Shared installer-runtime authority imported directly into integration suites"
+    - "Supported-only `--all` fixtures assert unsupported runtime directories are absent"
+key-files:
+  created:
+    - ".planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-SUMMARY.md"
+  modified:
+    - ".gitignore"
+    - "tests/integration/multi-runtime.test.js"
+    - "tests/integration/cross-runtime-kb.test.js"
+key-decisions:
+  - "Installer integration suites now consume `SUPPORTED_INSTALLER_RUNTIMES` instead of preserving local four-runtime constants."
+  - "Shared-KB `--all` fixtures prove supported-runtime installs by asserting Claude/Codex presence and Gemini/OpenCode absence."
+patterns-established:
+  - "Supported-only installer regression contract: `--all` tests fail if runtime outputs drift away from the shared runtime-support helper."
+duration: 10min
+completed: 2026-04-21
+---
+
+# Phase 59.1 Plan 02: Drop Gemini And OpenCode From Installer Scope Summary
+
+**Installer regression coverage now treats Claude Code and Codex CLI as the only supported `--all` outputs, with shared-KB smoke tests and local byproduct hygiene aligned to the same authority.**
+
+## Performance
+- **Duration:** 10min
+- **Tasks:** 2
+- **Files modified:** 3
+
+## Accomplishments
+- Added defensive `.gitignore` coverage for repo-local `.gemini/` and `.opencode/` byproducts created by older installs or local verification.
+- Rewrote `tests/integration/multi-runtime.test.js` around `SUPPORTED_INSTALLER_RUNTIMES`, replacing the old four-runtime worldview with Claude/Codex-only layout, parity, and absence assertions.
+- Updated `tests/integration/cross-runtime-kb.test.js` so every installer-driven `--all` fixture proves supported-only output while leaving KB verb coverage and `kb link show --both` behavior untouched.
+
+## Task Commits
+1. **Task 1: Rewrite the multi-runtime integration suite around the supported-only runtime authority and add byproduct ignore coverage** - `0e1a9e7f`
+2. **Task 2: Update shared-KB `--all` coverage to supported-only semantics without touching unrelated `kb link --both` behavior** - `0e4b2548`
+
+## Files Created/Modified
+- `.gitignore` - Ignores repo-local `.gemini/` and `.opencode/` verification byproducts alongside the existing local runtime outputs.
+- `tests/integration/multi-runtime.test.js` - Narrows installer layout, parity, and runtime-detection checks to the supported Claude/Codex runtime set imported from the shared authority helper.
+- `tests/integration/cross-runtime-kb.test.js` - Makes every installer-driven `--all` setup prove supported-only runtime output before exercising shared-KB behavior.
+
+## Decisions & Deviations
+### Key decisions
+
+- Imported `SUPPORTED_INSTALLER_RUNTIMES` directly into the multi-runtime suite instead of keeping any local runtime list.
+- Centralized cross-runtime KB install setup behind supported-only output assertions so unsupported runtime directories cannot silently reappear.
+
+### Deviations from plan
+
+None - plan executed exactly as written.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+Phase 59.1’s installer regression layer now mirrors the supported-runtime contract from Plan 01, so follow-on installer or release-note work can rely on tests that fail when Gemini/OpenCode outputs reappear.
+
+## Self-Check: PASSED
+
+- `FOUND: .planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-SUMMARY.md`
+- `FOUND: 0e1a9e7f`
+- `FOUND: 0e4b2548`

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-PLAN.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-PLAN.md
@@ -1,0 +1,161 @@
+---
+phase: 59.1-drop-gemini-and-opencode-from-installer-scope
+plan: "03"
+signature:
+  role: planner
+  harness: codex-cli
+  platform: codex
+  vendor: openai
+  model: gpt-5
+  reasoning_effort: not_available
+  profile: quality
+  gsd_version: 1.19.6+dev
+  generated_at: "2026-04-21T07:46:17Z"
+  session_id: "019daefc-cb6e-7ab3-b07c-d4879132df4c"
+  provenance_status:
+    role: derived
+    harness: derived
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: derived
+    reasoning_effort: not_available
+    profile: derived
+    gsd_version: derived
+    generated_at: exposed
+    session_id: exposed
+  provenance_source:
+    role: artifact_role
+    harness: runtime_context
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: developer_instruction
+    reasoning_effort: env:CODEX_REASONING_EFFORT_unset
+    profile: config:model_profile
+    gsd_version: config:gsd_reflect_version
+    generated_at: writer_clock
+    session_id: env:CODEX_THREAD_ID
+type: execute
+wave: 2
+depends_on:
+  - "01"
+files_modified:
+  - README.md
+  - .planning/PROJECT.md
+  - get-shit-done/references/capability-matrix.md
+  - CHANGELOG.md
+autonomous: true
+user_setup: []
+must_haves:
+  truths:
+    - "Present-tense live docs stop claiming active four-runtime installer support: README install examples, `.planning/PROJECT.md` runtime framing, and the capability-matrix support language all mirror the Claude/Codex-only installer authority from Plan 01."
+    - "The capability matrix keeps deprecated Gemini/OpenCode columns as historical reference where already marked `[D]`, but no present-tense text still says those runtimes are supported installer targets or that their installer flags still work."
+    - "`CHANGELOG.md` Unreleased records the v1.20 installer-scope breaking change: `--all` now means supported runtimes only, and `--gemini`/`--opencode`/legacy installer `--both` now fail with migration guidance."
+    - "No execution-time doc change widens into archive cleanup or broad runtime-taxonomy rewrite; only live authority mirrors and the release-note disposition move in this plan."
+  artifacts:
+    - path: "README.md"
+      provides: "User-facing install examples aligned to the supported installer runtimes"
+      contains: "--claude"
+    - path: ".planning/PROJECT.md"
+      provides: "Top-level live project framing updated away from present-tense four-runtime support"
+      contains: "Codex CLI"
+    - path: "get-shit-done/references/capability-matrix.md"
+      provides: "Runtime-capability reference aligned to supported-only installer behavior while retaining deprecated historical columns"
+      contains: "The two supported runtimes are"
+    - path: "CHANGELOG.md"
+      provides: "Unreleased release-note entry for the installer-scope breaking change"
+      contains: "## [Unreleased]"
+  key_links:
+    - from: "README.md"
+      to: "bin/install.js"
+      via: "public install examples mirror supported-only flags and `--all` semantics from Plan 01"
+      pattern: "--all|--claude|--codex"
+    - from: "get-shit-done/references/capability-matrix.md"
+      to: "get-shit-done/bin/lib/runtime-support.cjs"
+      via: "human-facing capability/reference language mirrors the canonical supported-runtime authority rather than defining its own runtime list"
+      pattern: "supported runtimes"
+---
+
+<objective>
+Bring the live mirror surfaces and release-note record into line with the installer authority created in Plan 01.
+
+Purpose: Phase 59.1 stays incomplete if README, PROJECT framing, and the capability matrix still speak in a stale four-runtime voice after the installer itself has been narrowed.
+Output: Updated live mirror docs plus an Unreleased changelog note for the v1.20 installer-scope change.
+</objective>
+
+<execution_context>
+@./.codex/get-shit-done-reflect/workflows/execute-plan.md
+@./.codex/get-shit-done-reflect/templates/summary-standard.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/REQUIREMENTS.md
+@.planning/STATE.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-RESEARCH.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-SUMMARY.md
+@README.md
+@.planning/PROJECT.md
+@get-shit-done/references/capability-matrix.md
+@CHANGELOG.md
+</context>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Rewrite live mirror docs and capability references to the supported-only installer contract</name>
+  <files>README.md, .planning/PROJECT.md, get-shit-done/references/capability-matrix.md</files>
+  <action>Update the present-tense live mirror surfaces that still claim four-runtime support.
+
+Concrete scope:
+
+- `README.md`: replace the runtime prompt/install examples so only Claude Code, Codex CLI, and supported-only `--all` are documented. Remove `--opencode`/`--gemini` examples and any prompt text that offers OpenCode/Gemini as normal install choices.
+- `.planning/PROJECT.md`: update the present-tense runtime-support claims called out in research (`Supports 4 runtimes`, `4 runtimes supported`, compatibility wording that lists all four). Keep historical milestone references intact; only current-tense product framing should change.
+- `get-shit-done/references/capability-matrix.md`: keep the deprecated OpenCode/Gemini columns/sections where they already exist for historical reference, but update the top notice and any current-tense "supported runtimes" wording so it matches the new installer reality from Plan 01. Replace phrases like "installer flags still work" or "all four supported runtimes" with the supported-only Claude/Codex contract plus explicit deprecated status.
+
+Do not widen this task into archive cleanup, old changelog rewriting, or a whole-table redesign of the capability matrix. The goal is live-surface truthfulness, not taxonomic perfection.</action>
+  <verify>`rg -n -- '--opencode|--gemini' README.md` returns no installer-example hits. `rg -n "4 runtimes supported|Supports 4 runtimes|all four supported runtimes" .planning/PROJECT.md get-shit-done/references/capability-matrix.md` returns no present-tense matches. `rg -n "The two supported runtimes are" get-shit-done/references/capability-matrix.md` returns the updated authority statement.</verify>
+  <done>README, PROJECT, and capability-matrix present-tense language all mirror the Claude/Codex-only installer contract without rewriting historical reference material.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Record the v1.20 installer-scope breaking change in `CHANGELOG.md`</name>
+  <files>CHANGELOG.md</files>
+  <action>Add an Unreleased changelog note that records the installer-scope change as release-note-worthy behavior for v1.20.
+
+Place the note under `## [Unreleased]` in the appropriate subsection(s), using the repo's existing changelog style. The note should state:
+
+- Installer support is now Claude Code + Codex CLI only.
+- `--all` now means supported runtimes only.
+- `--gemini`, `--opencode`, and legacy installer `--both` now fail with migration guidance instead of installing unsupported runtimes.
+
+Mention defensive `.gitignore` byproduct coverage only if it fits naturally. Do not edit historical release sections just to normalize older runtime language.</action>
+  <verify>`sed -n '1,40p' CHANGELOG.md` shows an Unreleased entry for the installer-scope change. `rg -n "supported runtimes only|--gemini|--opencode|--both" CHANGELOG.md` finds the new Unreleased note.</verify>
+  <done>`CHANGELOG.md` Unreleased makes the installer-scope change explicit before v1.20.0 release, so the runtime drop is not hidden in implementation-only artifacts.</done>
+</task>
+
+</tasks>
+
+<verification>
+- README no longer documents Gemini/OpenCode install flags.
+- `.planning/PROJECT.md` no longer claims present-tense four-runtime support.
+- Capability matrix support language matches the supported-only installer contract while preserving deprecated historical columns.
+- `CHANGELOG.md` Unreleased records the breaking installer change for v1.20.
+</verification>
+
+<narrowing_decisions>
+## Narrowing Decisions
+
+The execution phase records the breaking-change disposition in `CHANGELOG.md` and updates the live mirror docs, but it does not reopen `.planning/ROADMAP.md` or `.planning/REQUIREMENTS.md` during execution. The 59.1 phase insertion and these PLAN artifacts already carry the planning-layer scope; widening execution into extra planning-authority rewrites would exceed RR-4's narrow installer-correction boundary.
+</narrowing_decisions>
+
+<success_criteria>
+- No present-tense live source document still presents Gemini/OpenCode as supported installer targets.
+- The v1.20 release note path explicitly records the installer-scope change.
+- Historical reference material is preserved where useful instead of being mass-rewritten.
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-SUMMARY.md`
+</output>

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-PLAN.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-PLAN.md
@@ -35,9 +35,10 @@ signature:
     generated_at: writer_clock
     session_id: env:CODEX_THREAD_ID
 type: execute
-wave: 2
+wave: 3
 depends_on:
   - "01"
+  - "02"
 files_modified:
   - README.md
   - .planning/PROJECT.md
@@ -45,9 +46,11 @@ files_modified:
   - CHANGELOG.md
 autonomous: true
 user_setup: []
+resolves_signals:
+  - sig-2026-04-21-installer-advertises-gemini-opencode-unsupported
 must_haves:
   truths:
-    - "Present-tense live docs stop claiming active four-runtime installer support: README install examples, `.planning/PROJECT.md` runtime framing, and the capability-matrix support language all mirror the Claude/Codex-only installer authority from Plan 01."
+    - "After Plans 01 and 02 land, the last remaining live support-surface drift is closed here: README install examples, `.planning/PROJECT.md` runtime framing, and the capability-matrix support language all mirror the Claude/Codex-only installer authority, so `sig-2026-04-21-installer-advertises-gemini-opencode-unsupported` can move to remediated without premature closure."
     - "The capability matrix keeps deprecated Gemini/OpenCode columns as historical reference where already marked `[D]`, but no present-tense text still says those runtimes are supported installer targets or that their installer flags still work."
     - "`CHANGELOG.md` Unreleased records the v1.20 installer-scope breaking change: `--all` now means supported runtimes only, and `--gemini`/`--opencode`/legacy installer `--both` now fail with migration guidance."
     - "No execution-time doc change widens into archive cleanup or broad runtime-taxonomy rewrite; only live authority mirrors and the release-note disposition move in this plan."
@@ -78,7 +81,7 @@ must_haves:
 <objective>
 Bring the live mirror surfaces and release-note record into line with the installer authority created in Plan 01.
 
-Purpose: Phase 59.1 stays incomplete if README, PROJECT framing, and the capability matrix still speak in a stale four-runtime voice after the installer itself has been narrowed.
+Purpose: Phase 59.1 stays incomplete if README, PROJECT framing, and the capability matrix still speak in a stale four-runtime voice after the installer and regression layers have been narrowed. This plan is intentionally sequenced after Plans 01 and 02 so it becomes the correct signal-closure point for the installer-scope drift.
 Output: Updated live mirror docs plus an Unreleased changelog note for the v1.20 installer-scope change.
 </objective>
 
@@ -95,6 +98,7 @@ Output: Updated live mirror docs plus an Unreleased changelog note for the v1.20
 @.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
 @.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-RESEARCH.md
 @.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-01-SUMMARY.md
+@.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-02-SUMMARY.md
 @README.md
 @.planning/PROJECT.md
 @get-shit-done/references/capability-matrix.md
@@ -106,7 +110,9 @@ Output: Updated live mirror docs plus an Unreleased changelog note for the v1.20
 <task type="auto">
   <name>Task 1: Rewrite live mirror docs and capability references to the supported-only installer contract</name>
   <files>README.md, .planning/PROJECT.md, get-shit-done/references/capability-matrix.md</files>
-  <action>Update the present-tense live mirror surfaces that still claim four-runtime support.
+  <action>This task completes signal `sig-2026-04-21-installer-advertises-gemini-opencode-unsupported` after Plan 01 removes unsupported installer behavior and Plan 02 lands the integration/byproduct regressions. The root cause was not only duplicated installer logic but also live mirror surfaces still advertising the stale four-runtime contract.
+
+Update the present-tense live mirror surfaces that still claim four-runtime support.
 
 Concrete scope:
 
@@ -153,6 +159,7 @@ The execution phase records the breaking-change disposition in `CHANGELOG.md` an
 <success_criteria>
 - No present-tense live source document still presents Gemini/OpenCode as supported installer targets.
 - The v1.20 release note path explicitly records the installer-scope change.
+- Completing this plan after Plans 01 and 02 is sufficient for execute-phase to mark `sig-2026-04-21-installer-advertises-gemini-opencode-unsupported` remediated without racing ahead of the remaining regression work.
 - Historical reference material is preserved where useful instead of being mass-rewritten.
 </success_criteria>
 

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-SUMMARY.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-SUMMARY.md
@@ -1,0 +1,120 @@
+---
+phase: 59.1-drop-gemini-and-opencode-from-installer-scope
+plan: "03"
+signature:
+  role: executor
+  harness: codex-cli
+  platform: codex
+  vendor: openai
+  model: gpt-5
+  reasoning_effort: not_available
+  profile: quality
+  gsd_version: 1.19.6+dev
+  generated_at: "2026-04-21T09:00:56Z"
+  session_id: "019daf42-3a9a-75c1-903a-d88699412a87"
+  provenance_status:
+    role: derived
+    harness: derived
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: derived
+    reasoning_effort: not_available
+    profile: derived
+    gsd_version: derived
+    generated_at: exposed
+    session_id: exposed
+  provenance_source:
+    role: artifact_role
+    harness: runtime_context
+    platform: derived_from_harness
+    vendor: derived_from_harness
+    model: developer_instruction
+    reasoning_effort: env:CODEX_REASONING_EFFORT_unset
+    profile: config:model_profile
+    gsd_version: config:gsd_reflect_version
+    generated_at: writer_clock
+    session_id: env:CODEX_THREAD_ID
+context_used_pct: 39
+subsystem: installer-docs
+tags: [installer, docs, changelog, claude, codex, gemini, opencode, phase-59.1]
+requires:
+  - phase: 59.1-01
+    provides: "Canonical supported-runtime installer authority and supported-only flag behavior"
+  - phase: 59.1-02
+    provides: "Regression coverage proving the installer now only targets supported runtimes"
+provides:
+  - "README install guidance now documents Claude Code, Codex CLI, and supported-only `--all` paths"
+  - "`.planning/PROJECT.md` present-tense runtime framing now mirrors the Claude/Codex-only support contract"
+  - "`get-shit-done/references/capability-matrix.md` now names Gemini/OpenCode as deprecated reference columns while recording that legacy installer flags fail with migration guidance"
+  - "`CHANGELOG.md` Unreleased now records the v1.20 installer-scope breaking change"
+affects: [installer, docs, release-notes, phase-59.1, signal-closure]
+tech-stack:
+  added: []
+  patterns:
+    - "Live support mirrors follow installer authority rather than preserving stale runtime taxonomy"
+    - "Deprecated runtime references remain historical/reference-only instead of active installer guidance"
+key-files:
+  created:
+    - ".planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-SUMMARY.md"
+  modified:
+    - "README.md"
+    - ".planning/PROJECT.md"
+    - "get-shit-done/references/capability-matrix.md"
+    - "CHANGELOG.md"
+key-decisions:
+  - "README and PROJECT present-tense runtime wording now advertise only the supported Claude Code and Codex CLI installer contract."
+  - "The capability matrix preserves deprecated Gemini/OpenCode columns for reference, but its support language and release notes now reflect that installer access is limited to Claude/Codex and legacy flags fail with migration guidance."
+patterns-established:
+  - "Support-surface truthfulness: live docs and release notes are updated as part of installer-scope corrections, not left behind as stale mirrors."
+duration: 7min
+completed: 2026-04-21
+---
+
+# Phase 59.1 Plan 03: Drop Gemini And OpenCode From Installer Scope Summary
+
+**Live mirror docs and release notes now match the supported-only installer contract, closing the last advertised Gemini/OpenCode support drift after Plans 01 and 02.**
+
+## Performance
+- **Duration:** 7min
+- **Tasks:** 2
+- **Files modified:** 4
+
+## Accomplishments
+- Rewrote `README.md` install guidance so the runtime prompt and non-interactive examples document only Claude Code, Codex CLI, and supported-only `--all`.
+- Updated `.planning/PROJECT.md` present-tense framing away from four-runtime support claims while leaving historical milestone references intact.
+- Corrected `get-shit-done/references/capability-matrix.md` support language so deprecated Gemini/OpenCode columns remain as reference only and no longer imply working installer targets.
+- Added an Unreleased changelog note for the v1.20 installer-scope breaking change, including supported-only `--all` semantics and failure guidance for `--gemini`, `--opencode`, and installer `--both`.
+
+## Task Commits
+1. **Task 1: Rewrite live mirror docs and capability references to the supported-only installer contract** - `c6685419`
+2. **Task 2: Record the v1.20 installer-scope breaking change in `CHANGELOG.md`** - `15ac0897`
+
+## Files Created/Modified
+- `README.md` - Narrows runtime prompt copy and non-interactive install examples to the supported installer targets.
+- `.planning/PROJECT.md` - Removes present-tense four-runtime support framing from the live project overview and constraints.
+- `get-shit-done/references/capability-matrix.md` - Aligns supported-runtime language with the installer contract while retaining deprecated columns for reference.
+- `CHANGELOG.md` - Adds the Unreleased note for the installer-scope breaking change.
+
+## Decisions & Deviations
+### Key decisions
+
+- Live docs now mirror the installer authority established in Plans 01 and 02 instead of preserving a stale four-runtime worldview.
+- Deprecated Gemini/OpenCode references stay in the capability matrix only as explicitly marked historical/reference columns, not as active installer guidance.
+
+### Deviations from plan
+
+None - plan executed exactly as written.
+
+## User Setup Required
+
+None - no external service configuration required.
+
+## Next Phase Readiness
+
+The installer authority, regression coverage, live mirror docs, and Unreleased release note now tell the same Claude/Codex-only story, so Phase 59.1 can close `sig-2026-04-21-installer-advertises-gemini-opencode-unsupported` without leaving public support-surface drift behind.
+
+## Self-Check: PASSED
+
+- `FOUND: .planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-03-SUMMARY.md`
+- `FOUND: c6685419`
+- `FOUND: 15ac0897`

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
@@ -1,0 +1,187 @@
+# Phase 59.1: Drop Gemini and OpenCode from installer scope - Context
+
+**Gathered:** 2026-04-21
+**Status:** Ready for planning
+**Mode:** Exploratory `--auto` -- typed-claim steering brief generated from prior decisions, live source evidence, and installer drift signals
+
+<domain>
+## Phase Boundary
+
+Phase 59.1 narrows the installer's live support surface to the project's current supported runtimes, Claude Code and Codex CLI. The phase covers installer/runtime-selection behavior, user-facing installer docs and help text, machine-checked scope enforcement, and defensive cleanup around runtime byproducts. It does not reopen the broader question of whether Gemini CLI or OpenCode should exist anywhere in historical records, telemetry schemas, or archived artifacts.
+
+</domain>
+
+<working_model>
+## Working Model & Assumptions
+
+### Runtime support contract
+
+**Current state:** The repo already decided to focus active support on Claude Code and Codex CLI, but the installer and some live docs still speak with a four-runtime voice.
+
+- **SB-1:** [evidenced:cited] The 2026-04-08 deliberation narrowed active support to Claude Code and Codex CLI; Gemini CLI and OpenCode were explicitly downgraded from active maintenance.
+- **SB-2:** [evidenced:cited] `get-shit-done/references/capability-matrix.md` already says Claude Code and Codex CLI are the two supported runtimes, and that `--gemini` / `--opencode` currently produce unsupported configurations.
+- **SB-3:** [evidenced:cited] `bin/install.js` still treats OpenCode and Gemini as first-class installer targets in flag parsing, default runtime expansion, directory resolution, and the interactive runtime chooser.
+- **SB-4:** [decided:reasoned] Phase 59.1 should make the installer's authoritative support surface match the current project support contract: Claude Code plus Codex CLI only.
+- **SB-5:** [assumed:reasoned] The supported-runtime set should become machine-checkable rather than living only in prose, so installer behavior and tests can share one scope authority.
+
+### Installer CLI behavior
+
+**Current state:** The CLI help surface still invites users onto deprecated runtime paths, and `--all` still means "all historical runtimes" rather than "all supported runtimes."
+
+- **CLI-1:** [evidenced:cited] Public installer surfaces still advertise `--opencode`, `--gemini`, and `--all` as normal install choices in both `bin/install.js` help text and `README.md`.
+- **CLI-2:** [evidenced:cited] `--all` currently expands to `['claude', 'opencode', 'gemini', 'codex']`, and the interactive chooser still offers OpenCode and Gemini as equal peers.
+- **CLI-3:** [decided:reasoned] After Phase 59.1, `--all` should mean all supported runtimes only: Claude Code and Codex CLI.
+- **CLI-4:** [assumed:reasoned] Explicit `--gemini` and `--opencode` invocations should fail fast with an unsupported-runtime message and migration guidance rather than silently continuing or mapping to another runtime.
+
+### Cleanup boundary
+
+**Current state:** Live source surfaces disagree about support scope, while historical artifacts still preserve the old four-runtime world.
+
+- **CB-1:** [evidenced:cited] Present-tense source surfaces still reflect four-runtime assumptions: `README.md` advertises Gemini/OpenCode install flags, `.planning/PROJECT.md` still says "4 runtimes supported," and the install tests still validate OpenCode/Gemini layouts as first-class outputs.
+- **CB-2:** [decided:reasoned] Phase 59.1 should update load-bearing source surfaces that advertise or validate installer support scope: installer code, live docs/help text, regression tests, runtime-capability references, and `.gitignore`.
+- **CB-3:** [governing:reasoned] Historical phase artifacts, archived audits, and old signals are evidence of how the project evolved; they should not be mass-rewritten just to make the history look cleaner.
+- **CB-4:** [assumed:reasoned] Repo-local `.gemini/` and `.opencode/` directories created during local installs are disposable byproducts, not fixtures that current source control should preserve or treat as supported outputs.
+
+### Regression and release handling
+
+**Current state:** The project has the human decision to de-scope Gemini/OpenCode, but no structural check that the installer obeys it.
+
+- **RR-1:** [evidenced:cited] No current test or manifest asserts that installer target expansion equals the declared supported-runtime set; this is why scope drift survived from the April 8 deliberation through Phase 59 execution.
+- **RR-2:** [decided:reasoned] Phase 59.1 must add at least one regression surface that couples declared runtime support to installer behavior so future scope drift fails mechanically.
+- **RR-3:** [assumed:reasoned] Because v1.19.x publicly exposed Gemini/OpenCode installer flags, v1.20.0 should treat their removal from supported installer behavior as a release-note-worthy behavioral change.
+- **RR-4:** [governing:reasoned] The phase should prefer the narrowest enforcement that closes installer-scope drift; it must not balloon into a full runtime-taxonomy rewrite across unrelated measurement, KB, or archive surfaces.
+
+### Claude's Discretion
+
+- Exact helper placement for the supported-runtime authority once the declaration surface is chosen
+- Exact split between unit and integration coverage, as long as the supported-runtime invariant is mechanically enforced
+
+</working_model>
+
+<constraints>
+## Derived Constraints
+
+- **DC-1:** [evidenced:cited] Source of truth is the repo source surface (`bin/install.js`, source docs, source tests); repo-local runtime mirrors are outputs and must not be hand-edited as the primary fix -- derived from `AGENTS.md`.
+- **DC-2:** [evidenced:cited] Phase 59.1 is an inserted urgent fix after Phase 59 and before the v1.20.0 release; the scope is installer-surface correction, not a general runtime-platform redesign -- derived from `.planning/ROADMAP.md` and `.planning/STATE.md`.
+- **DC-3:** [evidenced:cited] `bin/install.js` is a high-blast-radius hotspot, and `tests/unit/install.test.js` plus `tests/integration/multi-runtime.test.js` are the main regression surfaces that should move with it -- derived from `AGENTS.md` and the current test suite.
+- **DC-4:** [evidenced:cited] Runtime-capability authority documents are load-bearing: when runtime support surfaces change, `get-shit-done/references/capability-matrix.md` must stay aligned or closeout discipline breaks -- derived from the capability matrix header.
+- **DC-5:** [decided:reasoned] Phase 59.1 is about installer support scope, not retroactive normalization of historical runtime identifiers in KB entries, telemetry artifacts, or archived phase outputs.
+- **DC-6:** [evidenced:cited] `.gitignore` currently ignores `.claude/` and `.codex/` but not `.gemini/` / `.opencode/`, so local verification can still produce noisy runtime byproducts unless the phase closes that gap.
+
+</constraints>
+
+<guardrails>
+## Epistemic Guardrails
+
+- **G-1:** [governing:reasoned] When live sources disagree, prioritize the newest explicit support-scope chain: the 2026-04-08 deliberation, the capability-matrix deprecation notice, and the 2026-04-21 signal/state insertion outrank older "4 runtimes supported" prose.
+- **G-2:** [governing:reasoned] Unsupported runtime behavior must be explicit. The phase should not silently install Claude/Codex when the user asked for Gemini/OpenCode, and it should not report success for unsupported installs.
+- **G-3:** [governing:reasoned] Keep the phase boundary tight: correct live installer authority surfaces and current docs/tests, but do not rewrite archives, telemetry schemas, or KB history just to harmonize wording.
+- **G-4:** [stipulated:reasoned] Planning must include at least one regression that compares installer target expansion against a declared supported-runtime set rather than relying on prose discipline alone.
+- **G-5:** [governing:reasoned] Any present-tense live source document that still claims active four-runtime support after 59.1 planning should be treated as an unfixed bug or an explicit named deferral, not as harmless drift.
+
+</guardrails>
+
+<questions>
+## Open Questions
+
+### Q1: [open:bare] Where should the canonical supported-runtime declaration live? <!-- typed by context-checker -->
+**Research program:** Compare the narrowest viable authority surfaces for runtime support: an installer-exported constant, an existing config/manifest surface, or a runtime-reference document consumed by both tests and installer helpers. Evaluate duplication risk, ease of testing, and whether the location is load-bearing enough to prevent future drift.
+**Downstream decisions affected:** Helper placement, regression-test shape, release-note linkage, and how many files need to be updated whenever runtime support changes.
+**Reversibility:** MEDIUM — centralizing in one place now is reversible, but choosing a weak/non-load-bearing location risks repeating the same scope drift.
+
+### Q2: [open:bare] What is the migration and cleanup contract for legacy Gemini/OpenCode users? <!-- typed by context-checker -->
+**Research program:** Inspect current install and uninstall flows to determine whether legacy runtime paths should retain a narrow cleanup-only escape hatch, or whether unsupported flags should fail immediately with manual migration guidance. Check user-facing docs and release-note expectations before choosing the behavior.
+**Downstream decisions affected:** CLI UX for deprecated flags, uninstall behavior, release-note wording, and whether Phase 59.1 touches only install paths or also cleanup paths.
+**Reversibility:** MEDIUM — a narrow compatibility shim can be added later, but a misleading shim shipped now can keep unsupported installs alive by inertia.
+
+### Q3: [open:bare] Which live source documents must be corrected in Phase 59.1, and which should be explicitly left historical? <!-- typed by context-checker -->
+**Research program:** Inventory present-tense runtime-support claims in `README.md`, `.planning/PROJECT.md`, `get-shit-done/references/capability-matrix.md`, and source tests. Use audience and load-bearing authority as the deciding criteria: current user-facing or workflow-driving docs should align now; archival/history artifacts can remain historical.
+**Downstream decisions affected:** Patch scope, commit grouping, release messaging, and whether contradictory source claims survive into v1.20.0.
+**Reversibility:** LOW — under-correcting live authority docs risks shipping a contradictory support contract into the release.
+
+</questions>
+
+<dependencies>
+## Claim Dependencies
+
+| Claim | Depends On | Vulnerability |
+|-------|-----------|---------------|
+| **SB-4** installer support surface should be Claude+Codex only | **SB-1**, **SB-2**, **SB-3** | LOW -- the decision is strongly grounded in both prior deliberation and current code drift evidence |
+| **CLI-3** `--all` should mean supported runtimes only | **SB-4** | LOW -- once supported scope is fixed, `--all` follows directly |
+| **CLI-4** deprecated runtime flags should fail fast with guidance | **RR-3**, **Q2** | MEDIUM -- user-facing behavior depends on how much migration compatibility is still warranted |
+| **CB-2** update live source surfaces, not just installer code | **SB-4**, **CB-1** | LOW -- the stale surfaces are directly evidenced and tied to the same scope contract |
+| **RR-2** add a mechanical regression for runtime scope | **SB-5**, **RR-1** | HIGH -- a decided claim still depends on SB-5's unvalidated shared-authority assumption while Q1 remains open <!-- corrected by context-checker: was MEDIUM --> |
+| **DC-5** do not widen into historical-runtime taxonomy cleanup | **RR-4**, **G-3** | LOW -- the scope boundary is explicit in both roadmap/state and the governance posture for this phase |
+
+</dependencies>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Scope Authority
+- `AGENTS.md` — repo-specific source-vs-installed authority, installer hotspot guidance, and regression-surface expectations
+- `.planning/ROADMAP.md` — Phase 59.1 entry and its dependency on Phase 59
+- `.planning/STATE.md` — roadmap-evolution entry that names the trigger, exact scope, and required release timing for Phase 59.1
+- `.planning/deliberations/drop-gemini-opencode-focus-codex.md` — authoritative 2026-04-08 decision to narrow active support to Claude Code + Codex CLI
+
+### Runtime Contract And Drift Evidence
+- `get-shit-done/references/capability-matrix.md` — current supported-runtime declaration and XRT-01 closeout discipline
+- `.planning/knowledge/signals/get-shit-done-reflect/2026-04-21-installer-advertises-gemini-opencode-unsupported.md` — concrete failure report and remediation sketch for this inserted phase
+- `.planning/knowledge/signals/get-shit-done-reflect/2026-02-23-installer-clobbers-force-tracked-files.md` — installer blast-radius reminder; changes must account for whole-directory installer behavior
+
+### Live Source Surfaces To Reconcile
+- `README.md` — public non-interactive install examples still advertise deprecated runtime flags
+- `.planning/PROJECT.md` — current top-level project description still contains stale four-runtime support claims in present tense
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `bin/install.js` — centralized runtime selection, path resolution, help text, interactive chooser, converter dispatch, and install/uninstall orchestration all live here
+- `get-shit-done/bin/lib/update-target.cjs` — existing codex-only resolver pattern already models explicit runtime narrowing and unsupported-runtime errors
+- `tests/unit/install.test.js` — direct installer helper imports plus subprocess install smoke tests make it the fastest regression surface for runtime-scope logic
+- `tests/integration/multi-runtime.test.js` — shared layout and path-leak helpers already validate runtime-specific installs and can be re-scoped around supported runtimes
+- `tests/integration/cross-runtime-kb.test.js` — current `--all` semantics are exercised here, so changing `--all` has integration-test blast radius beyond the installer unit suite
+
+### Established Patterns
+- Installer behavior is validated through tempdir subprocess tests plus file-layout assertions, not by mocking every branch
+- Runtime-surface changes are expected to align with `get-shit-done/references/capability-matrix.md`
+- Source paths are canonical; generated `.claude/`, `.codex/`, `.gemini/`, and `.opencode/` outputs are deployment artifacts, not design authority
+
+### Integration Points
+- `bin/install.js:68-170` — CLI flags, runtime expansion, directory naming, and runtime-specific config-dir resolution
+- `bin/install.js:224-229` — user-facing installer help text
+- `bin/install.js:3181-3203` — interactive runtime picker and `All` expansion
+- `README.md:95-111` — user-facing non-interactive install examples
+- `.gitignore:8-10, 32-36` — current local-runtime ignore coverage
+- `tests/unit/install.test.js:30-120, 1925-1958` — installer flag smoke tests and `--all` expectations
+- `tests/integration/multi-runtime.test.js:74-112, 200-260` — runtime layout helpers and OpenCode/Gemini validation surface
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- The core user directive remains the same as the 2026-04-08 deliberation: "drop support for gemini and opencode and just focus on doing codex and claude code really well"
+- The inserted-phase scope in `.planning/STATE.md` is intentionally concrete: strip Gemini/OpenCode flags, path resolvers, frontmatter conversion, tool-name mapping, and help text; add a runtime-scope regression; add defensive `.gitignore` coverage; and record release-note impact
+- The capability matrix currently encodes an intermediate state: Gemini/OpenCode are already deprecated in prose, but the installer still exposes them as if they are normal
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Full project-wide purge of every historical Gemini/OpenCode mention across archived phase artifacts, old audits, and telemetry/KB history — outside Phase 59.1's installer-scope boundary
+- Any future reintroduction of Gemini/OpenCode as community plugins or separately maintained adapters — would be its own roadmap item, not part of this corrective phase
+- Broader runtime-taxonomy cleanup outside installer scope (for example resume-work path examples, long-tail template enums, or historical compatibility echoes) unless planning proves a specific live source surface is still load-bearing for v1.20.0
+
+</deferred>
+
+---
+
+*Phase: 59.1-drop-gemini-and-opencode-from-installer-scope*
+*Context gathered: 2026-04-21*

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md
@@ -50,6 +50,7 @@ Phase 59.1 narrows the installer's live support surface to the project's current
 - **RR-2:** [decided:reasoned] Phase 59.1 must add at least one regression surface that couples declared runtime support to installer behavior so future scope drift fails mechanically.
 - **RR-3:** [assumed:reasoned] Because v1.19.x publicly exposed Gemini/OpenCode installer flags, v1.20.0 should treat their removal from supported installer behavior as a release-note-worthy behavioral change.
 - **RR-4:** [governing:reasoned] The phase should prefer the narrowest enforcement that closes installer-scope drift; it must not balloon into a full runtime-taxonomy rewrite across unrelated measurement, KB, or archive surfaces.
+- **RR-5:** [assumed:reasoned] For Phase 59.1 planning, the supported-runtime declaration should live in a source-level authority consumed directly by installer code and regression tests, with user-facing docs mirroring that authority rather than defining it.
 
 ### Claude's Discretion
 
@@ -81,26 +82,6 @@ Phase 59.1 narrows the installer's live support surface to the project's current
 
 </guardrails>
 
-<questions>
-## Open Questions
-
-### Q1: [open:bare] Where should the canonical supported-runtime declaration live? <!-- typed by context-checker -->
-**Research program:** Compare the narrowest viable authority surfaces for runtime support: an installer-exported constant, an existing config/manifest surface, or a runtime-reference document consumed by both tests and installer helpers. Evaluate duplication risk, ease of testing, and whether the location is load-bearing enough to prevent future drift.
-**Downstream decisions affected:** Helper placement, regression-test shape, release-note linkage, and how many files need to be updated whenever runtime support changes.
-**Reversibility:** MEDIUM — centralizing in one place now is reversible, but choosing a weak/non-load-bearing location risks repeating the same scope drift.
-
-### Q2: [open:bare] What is the migration and cleanup contract for legacy Gemini/OpenCode users? <!-- typed by context-checker -->
-**Research program:** Inspect current install and uninstall flows to determine whether legacy runtime paths should retain a narrow cleanup-only escape hatch, or whether unsupported flags should fail immediately with manual migration guidance. Check user-facing docs and release-note expectations before choosing the behavior.
-**Downstream decisions affected:** CLI UX for deprecated flags, uninstall behavior, release-note wording, and whether Phase 59.1 touches only install paths or also cleanup paths.
-**Reversibility:** MEDIUM — a narrow compatibility shim can be added later, but a misleading shim shipped now can keep unsupported installs alive by inertia.
-
-### Q3: [open:bare] Which live source documents must be corrected in Phase 59.1, and which should be explicitly left historical? <!-- typed by context-checker -->
-**Research program:** Inventory present-tense runtime-support claims in `README.md`, `.planning/PROJECT.md`, `get-shit-done/references/capability-matrix.md`, and source tests. Use audience and load-bearing authority as the deciding criteria: current user-facing or workflow-driving docs should align now; archival/history artifacts can remain historical.
-**Downstream decisions affected:** Patch scope, commit grouping, release messaging, and whether contradictory source claims survive into v1.20.0.
-**Reversibility:** LOW — under-correcting live authority docs risks shipping a contradictory support contract into the release.
-
-</questions>
-
 <dependencies>
 ## Claim Dependencies
 
@@ -108,9 +89,9 @@ Phase 59.1 narrows the installer's live support surface to the project's current
 |-------|-----------|---------------|
 | **SB-4** installer support surface should be Claude+Codex only | **SB-1**, **SB-2**, **SB-3** | LOW -- the decision is strongly grounded in both prior deliberation and current code drift evidence |
 | **CLI-3** `--all` should mean supported runtimes only | **SB-4** | LOW -- once supported scope is fixed, `--all` follows directly |
-| **CLI-4** deprecated runtime flags should fail fast with guidance | **RR-3**, **Q2** | MEDIUM -- user-facing behavior depends on how much migration compatibility is still warranted |
+| **CLI-4** deprecated runtime flags should fail fast with guidance | **SB-4**, **RR-3** | MEDIUM -- user-facing behavior still depends on the release/migration assumption captured in RR-3 |
 | **CB-2** update live source surfaces, not just installer code | **SB-4**, **CB-1** | LOW -- the stale surfaces are directly evidenced and tied to the same scope contract |
-| **RR-2** add a mechanical regression for runtime scope | **SB-5**, **RR-1** | HIGH -- a decided claim still depends on SB-5's unvalidated shared-authority assumption while Q1 remains open <!-- corrected by context-checker: was MEDIUM --> |
+| **RR-2** add a mechanical regression for runtime scope | **RR-5**, **RR-1** | HIGH -- a decided claim still depends on RR-5's unvalidated shared-authority assumption <!-- corrected after checker: this remains a decided-on-assumed chain --> |
 | **DC-5** do not widen into historical-runtime taxonomy cleanup | **RR-4**, **G-3** | LOW -- the scope boundary is explicit in both roadmap/state and the governance posture for this phase |
 
 </dependencies>

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-DISCUSSION-LOG.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-DISCUSSION-LOG.md
@@ -1,0 +1,302 @@
+# Phase 59.1: Drop Gemini and OpenCode from installer scope - Discussion Log
+
+> **Justificatory sidecar.** Consumed by `gsdr-context-checker` for claim verification.
+> Also serves as the human-readable audit trail of this exploratory `--auto` discuss pass.
+
+**Date:** 2026-04-21
+**Phase:** 59.1-drop-gemini-and-opencode-from-installer-scope
+**Mode:** exploratory `--auto`
+**Areas discussed:** Runtime support contract, Installer CLI behavior, Cleanup boundary, Regression and release handling
+
+***
+
+## Gray Areas (Audit Trail)
+
+### Runtime support contract
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Keep Gemini/OpenCode installable but unsupported | Preserve the current "flags still work" state and rely on documentation to explain the deprecation | |
+| Remove Gemini/OpenCode from installer authority surfaces | Make installer behavior match the current Claude/Codex support contract | ✓ |
+| Add a hidden experimental path | Remove normal docs/help, but preserve a hidden opt-in implementation path | |
+
+**User's choice:** `[auto]` Remove Gemini/OpenCode from installer authority surfaces
+**Notes:** Auto-selected because the phase title, `STATE.md`, and the new 2026-04-21 signal all define this phase as a scope-correction slice rather than a doc-only deprecation pass.
+
+### Installer CLI behavior
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Fail fast with migration guidance | Unsupported runtime flags stop immediately and explain the new support boundary | ✓ |
+| Warn but continue unsupported install | Keep old behavior, but label it unsupported | |
+| Silently ignore deprecated flags | Avoid breakage at the cost of surprising installs | |
+
+**User's choice:** `[auto]` Fail fast with migration guidance
+**Notes:** Auto-selected as the most honest default. Silent or warning-only behavior would preserve the very ambiguity this phase is trying to remove. Whether uninstall gets a narrow legacy cleanup path remains open for research.
+
+### Cleanup boundary
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Update installer code only | Fix runtime selection but leave docs/tests/history to catch up later | |
+| Update live installer authority surfaces | Fix installer code plus live docs, tests, capability references, and defensive `.gitignore` coverage | ✓ |
+| Rewrite every historical mention | Purge Gemini/OpenCode references from archives, prior phases, and old artifacts too | |
+
+**User's choice:** `[auto]` Update live installer authority surfaces
+**Notes:** Auto-selected because the drift is visible in README/help/tests right now, but rewriting history would exceed the phase boundary and destroy useful provenance.
+
+### Regression and release handling
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Rely on prose discipline | Update docs and trust future reviewers to remember the support boundary | |
+| Add a machine-checked support-scope invariant | Declare supported runtimes once and test installer behavior against it | ✓ |
+| Leave regression to release-time manual review | Re-check the installer manually before each milestone release | |
+
+**User's choice:** `[auto]` Add a machine-checked support-scope invariant
+**Notes:** Auto-selected because the April 8 deprecation decision already proved prose-only discipline is insufficient. The exact declaration surface is still open and is tracked as Q1.
+
+### Claude's Discretion
+
+- Exact helper/file placement once the supported-runtime declaration surface is chosen
+- Exact unit-vs-integration test split after the invariant is defined
+
+### Deferred Ideas
+
+- Full historical cleanup of archived Gemini/OpenCode references
+- Any future community-plugin path for Gemini/OpenCode rather than core installer support
+- Runtime-taxonomy cleanup outside the installer support surface
+
+***
+
+## Claim Justifications
+
+### Runtime support contract
+
+**[evidenced:cited] SB-1: The 2026-04-08 deliberation narrowed active support to Claude Code and Codex CLI; Gemini CLI and OpenCode were explicitly downgraded from active maintenance.**
+- **Citation:** `.planning/deliberations/drop-gemini-opencode-focus-codex.md:41-50,59`
+- **Verification:** Read the decision block directly. It is current and matches the later roadmap-evolution note in `.planning/STATE.md`.
+
+**[evidenced:cited] SB-2: `get-shit-done/references/capability-matrix.md` already says Claude Code and Codex CLI are the two supported runtimes, and that `--gemini` / `--opencode` currently produce unsupported configurations.**
+- **Citation:** `get-shit-done/references/capability-matrix.md:18-23`
+- **Verification:** Read the deprecation notice directly. It is present-tense runtime authority, not historical commentary.
+
+**[evidenced:cited] SB-3: `bin/install.js` still treats OpenCode and Gemini as first-class installer targets in flag parsing, default runtime expansion, directory resolution, and the interactive runtime chooser.**
+- **Citation:** `bin/install.js:72-83`, `bin/install.js:93-161`, `bin/install.js:3181-3203`
+- **Verification:** Inspected the live source. The installer still parses explicit Gemini/OpenCode flags, expands `--all` to four runtimes, resolves both runtime directories, and offers both in the interactive chooser.
+
+**[decided:reasoned] SB-4: Phase 59.1 should make the installer's authoritative support surface match the current project support contract: Claude Code plus Codex CLI only.**
+- **Alternatives considered:** Keep deprecated installs functional but unsupported; preserve a hidden experimental path
+- **Why rejected:** Both alternatives keep scope ambiguity alive at the exact authority surface that users actually execute
+- **User said:** `.planning/deliberations/drop-gemini-opencode-focus-codex.md:59` records: "drop support for gemini and opencode and just focus on doing codex and claude code really well"
+
+**[assumed:reasoned] SB-5: The supported-runtime set should become machine-checkable rather than living only in prose, so installer behavior and tests can share one scope authority.**
+- **Challenge protocol:** If current consumers cannot share one authority without creating a worse second source of truth, the planner should choose the narrowest central declaration and document the tradeoff
+- **Evidence checked:** `.planning/knowledge/signals/get-shit-done-reflect/2026-04-21-installer-advertises-gemini-opencode-unsupported.md:69-73` explicitly names the lack of a machine-checkable supported-runtime list as the structural cause
+- **Why reasonable:** The drift persisted precisely because support scope lived only in human memory and prose
+
+### Installer CLI behavior
+
+**[evidenced:cited] CLI-1: Public installer surfaces still advertise `--opencode`, `--gemini`, and `--all` as normal install choices in both `bin/install.js` help text and `README.md`.**
+- **Citation:** `bin/install.js:229`, `README.md:95-111`
+- **Verification:** Read the live help text and README install examples; both still present deprecated runtime flags as routine usage.
+
+**[evidenced:cited] CLI-2: `--all` currently expands to `['claude', 'opencode', 'gemini', 'codex']`, and the interactive chooser still offers OpenCode and Gemini as equal peers.**
+- **Citation:** `bin/install.js:80-90`, `bin/install.js:3181-3203`
+- **Verification:** Read the runtime-expansion logic and the interactive menu callback. Both still encode the old four-runtime support contract.
+
+**[decided:reasoned] CLI-3: After Phase 59.1, `--all` should mean all supported runtimes only: Claude Code and Codex CLI.**
+- **Alternatives considered:** Preserve old four-runtime `--all`; remove `--all` entirely
+- **Why rejected:** Preserving old semantics perpetuates false support claims; removing `--all` entirely is a bigger CLI change than the phase needs
+- **User said:** The inserted phase scope in `.planning/STATE.md:330` explicitly says to declare a canonical supported-runtimes list and strip Gemini/OpenCode from installer scope
+
+**[assumed:reasoned] CLI-4: Explicit `--gemini` and `--opencode` invocations should fail fast with an unsupported-runtime message and migration guidance rather than silently continuing or mapping to another runtime.**
+- **Challenge protocol:** If research shows a narrower uninstall-only compatibility path is required for existing users, the planner can weaken install-time failure while preserving explicit messaging
+- **Evidence checked:** Current sources provide no explicit transition behavior; the evidence only establishes that continuing as-is is misleading
+- **Why reasonable:** A hard, explicit failure best matches the new support contract and avoids hidden unsupported installs
+
+### Cleanup boundary
+
+**[evidenced:cited] CB-1: Present-tense source surfaces still reflect four-runtime assumptions: `README.md` advertises Gemini/OpenCode install flags, `.planning/PROJECT.md` still says "4 runtimes supported," and the install tests still validate OpenCode/Gemini layouts as first-class outputs.**
+- **Citation:** `README.md:95-111`, `.planning/PROJECT.md:5`, `.planning/PROJECT.md:211-220`, `tests/unit/install.test.js:62-106`, `tests/unit/install.test.js:1925-1958`, `tests/integration/multi-runtime.test.js:77-112`, `tests/integration/multi-runtime.test.js:200-260`
+- **Verification:** Read each live source surface. They consistently show the old support shape even after the deprecation decision.
+
+**[decided:reasoned] CB-2: Phase 59.1 should update load-bearing source surfaces that advertise or validate installer support scope: installer code, live docs/help text, regression tests, runtime-capability references, and `.gitignore`.**
+- **Alternatives considered:** Fix installer only; rewrite every historical reference
+- **Why rejected:** Fixing installer only leaves contradictory live authority behind; rewriting history is unnecessary scope expansion
+- **User said:** No new user input in this `--auto` pass; scope is carried forward from `.planning/STATE.md:330`
+
+**[governing:reasoned] CB-3: Historical phase artifacts, archived audits, and old signals are evidence of how the project evolved; they should not be mass-rewritten just to make the history look cleaner.**
+- **Source:** GSD's epistemic-rigor posture and the repo's commitment to preserving planning history as operational evidence
+- **Scope of governance:** Constrains phase scope so the planner distinguishes live authority docs from archives
+
+**[assumed:reasoned] CB-4: Repo-local `.gemini/` and `.opencode/` directories created during local installs are disposable byproducts, not fixtures that current source control should preserve or treat as supported outputs.**
+- **Challenge protocol:** If any current source test intentionally depends on those directories as supported outputs, the phase must rewrite the test rather than grandfather the runtime
+- **Evidence checked:** `.gitignore:8-10, 32-36` ignores `.claude/` and `.codex/` but not `.gemini/` / `.opencode/`; the new 2026-04-21 signal cites the resulting untracked directories
+- **Why reasonable:** The repo already treats generated runtime mirrors as outputs rather than canonical source surfaces
+
+### Regression and release handling
+
+**[evidenced:cited] RR-1: No current test or manifest asserts that installer target expansion equals the declared supported-runtime set; this is why scope drift survived from the April 8 deliberation through Phase 59 execution.**
+- **Citation:** `.planning/knowledge/signals/get-shit-done-reflect/2026-04-21-installer-advertises-gemini-opencode-unsupported.md:64-73`
+- **Verification:** Read the signal's diagnosis and compared it against the current test suite, which validates layouts but not a shared support-scope invariant.
+
+**[decided:reasoned] RR-2: Phase 59.1 must add at least one regression surface that couples declared runtime support to installer behavior so future scope drift fails mechanically.**
+- **Alternatives considered:** Rely on capability-matrix prose; rely on release-time manual audit only
+- **Why rejected:** Both are the same prose-only approach that already failed between April 8 and April 21
+- **User said:** No new user input in this `--auto` pass; the carried-forward scope in `.planning/STATE.md:330` explicitly calls for "add regression test asserting installer targets = declared list"
+
+**[assumed:reasoned] RR-3: Because v1.19.x publicly exposed Gemini/OpenCode installer flags, v1.20.0 should treat their removal from supported installer behavior as a release-note-worthy behavioral change.**
+- **Challenge protocol:** If release artifact review shows the flags were never part of the published user path, the planner can downgrade this from breaking-change language to migration note
+- **Evidence checked:** `README.md:95-111` and `bin/install.js:229` show the flags as public-facing examples and help text
+- **Why reasonable:** User-visible CLI behavior is changing, so release messaging should not bury it
+
+**[governing:reasoned] RR-4: The phase should prefer the narrowest enforcement that closes installer-scope drift; it must not balloon into a full runtime-taxonomy rewrite across unrelated measurement, KB, or archive surfaces.**
+- **Source:** The inserted-roadmap entry is explicitly scoped to installer surfaces and release readiness, not global runtime-taxonomy cleanup
+- **Scope of governance:** Constrains planning choices about docs, tests, and helper placement
+
+### Derived Constraints
+
+**[evidenced:cited] DC-1: Source of truth is the repo source surface (`bin/install.js`, source docs, source tests); repo-local runtime mirrors are outputs and must not be hand-edited as the primary fix.**
+- **Citation:** `AGENTS.md:8-17,39-44,92-103`
+- **Verification:** Read the repo-level instructions supplied in-thread and confirmed they explicitly prioritize source paths over `.claude/`, `.codex/`, and similar mirrors.
+
+**[evidenced:cited] DC-2: Phase 59.1 is an inserted urgent fix after Phase 59 and before the v1.20.0 release; the scope is installer-surface correction, not a general runtime-platform redesign.**
+- **Citation:** `.planning/ROADMAP.md:391-399`, `.planning/STATE.md:329-330`
+- **Verification:** Read the roadmap entry and the state insertion note; both describe 59.1 as an urgent inserted phase with concrete installer-scope tasks.
+
+**[evidenced:cited] DC-3: `bin/install.js` is a high-blast-radius hotspot, and `tests/unit/install.test.js` plus `tests/integration/multi-runtime.test.js` are the main regression surfaces that should move with it.**
+- **Citation:** `AGENTS.md:105-109`; `tests/unit/install.test.js:30-120,1925-1958`; `tests/integration/multi-runtime.test.js:74-112,200-260`
+- **Verification:** Confirmed the repo instructions call out `bin/install.js` and those tests as the main installer/runtime regression surface, then read the tests to verify they currently encode the runtime matrix.
+
+**[evidenced:cited] DC-4: Runtime-capability authority documents are load-bearing: when runtime support surfaces change, `get-shit-done/references/capability-matrix.md` must stay aligned or closeout discipline breaks.**
+- **Citation:** `get-shit-done/references/capability-matrix.md:1-10`
+- **Verification:** Read the header comment; it explicitly says capability-surface phases must update the matrix as part of closeout.
+
+**[decided:reasoned] DC-5: Phase 59.1 is about installer support scope, not retroactive normalization of historical runtime identifiers in KB entries, telemetry artifacts, or archived phase outputs.**
+- **Alternatives considered:** Fold historical-runtime cleanup into 59.1; leave the scope boundary unstated
+- **Why rejected:** Folding history cleanup into 59.1 would turn a narrow installer correction into a broad taxonomy rewrite with unclear blast radius
+- **User said:** No direct user statement in this session; the boundary is inferred from the inserted phase scope in `.planning/STATE.md:330`
+
+**[evidenced:cited] DC-6: `.gitignore` currently ignores `.claude/` and `.codex/` but not `.gemini/` / `.opencode/`, so local verification can still produce noisy runtime byproducts unless the phase closes that gap.**
+- **Citation:** `.gitignore:8-10, 32-36`; `.planning/knowledge/signals/get-shit-done-reflect/2026-04-21-installer-advertises-gemini-opencode-unsupported.md:54-65`
+- **Verification:** Read `.gitignore` and the new signal; both confirm the asymmetric ignore coverage and the resulting untracked directories.
+
+### Epistemic Guardrails
+
+**[governing:reasoned] G-1: When live sources disagree, prioritize the newest explicit support-scope chain: the 2026-04-08 deliberation, the capability-matrix deprecation notice, and the 2026-04-21 signal/state insertion outrank older "4 runtimes supported" prose.**
+- **Source:** Support-scope authority is time-sensitive; newer explicit corrections supersede older present-tense prose when they conflict
+- **Scope of governance:** Determines which sources downstream agents should trust when PROJECT/README disagree with deliberation/state
+
+**[governing:reasoned] G-2: Unsupported runtime behavior must be explicit. The phase should not silently install Claude/Codex when the user asked for Gemini/OpenCode, and it should not report success for unsupported installs.**
+- **Source:** The signal is about installer authority drift, so silent fallback would reproduce the same epistemic problem in another form
+- **Scope of governance:** Constrains CLI UX and failure messaging for deprecated runtime flags
+
+**[governing:reasoned] G-3: Keep the phase boundary tight: correct live installer authority surfaces and current docs/tests, but do not rewrite archives, telemetry schemas, or KB history just to harmonize wording.**
+- **Source:** Scope guardrail from the discuss workflow plus the inserted-phase note that names specific installer-surface repairs
+- **Scope of governance:** Distinguishes live authority cleanup from historical normalization
+
+**[stipulated:reasoned] G-4: Planning must include at least one regression that compares installer target expansion against a declared supported-runtime set rather than relying on prose discipline alone.**
+- **Acknowledged as choice:** Yes -- this is an enforcement floor chosen for this phase, not a measured fact
+- **Calibration evidence:** The April 8 to April 21 drift window is the evidence that prose-only discipline is insufficient
+- **Reasonable range:** One strong invariant test is the minimum; more regression coverage may still be warranted depending on implementation split
+
+**[governing:reasoned] G-5: Any present-tense live source document that still claims active four-runtime support after 59.1 planning should be treated as an unfixed bug or an explicit named deferral, not as harmless drift.**
+- **Source:** The inserted phase exists precisely because contradictory live source claims were treated as harmless until the installer exposed them again
+- **Scope of governance:** Forces planner/executor closeout to account for remaining contradictions explicitly
+
+### Open Questions
+
+**[open] Q1: Where should the canonical supported-runtime declaration live?**
+- **What's been tried:** Read the installer, capability matrix, signal, and current tests to identify existing authority candidates
+- **Why unresolved:** The need for a single authority is clear, but the repo currently splits runtime knowledge across code, docs, and tests
+- **Research delegation:** Compare an installer-exported constant, an existing manifest/config surface, and a capability-reference-derived helper for duplication risk and testability
+
+**[open] Q2: What is the migration and cleanup contract for legacy Gemini/OpenCode users?**
+- **What's been tried:** Established that current install paths are publicly exposed and that the phase wants them removed from installer scope
+- **Why unresolved:** The repo has not yet answered whether uninstall/manual-cleanup compatibility should survive the install-path removal
+- **Research delegation:** Inspect uninstall code paths and release-note expectations to determine whether a cleanup-only escape hatch is warranted
+
+**[open] Q3: Which live source documents must be corrected in Phase 59.1, and which should be explicitly left historical?**
+- **What's been tried:** Identified README, PROJECT, capability matrix, installer help, and test surfaces as current live contradictions
+- **Why unresolved:** The exact cut line between "live authority" and "historical evidence" still needs a deliberate inventory rather than an intuitive sweep
+- **Research delegation:** Inventory present-tense runtime claims and sort them by authority and audience before task breakdown
+
+### Claim Dependencies
+
+| Claim | Depends On | Vulnerability |
+|-------|-----------|---------------|
+| **SB-4** installer support surface should be Claude+Codex only | **SB-1**, **SB-2**, **SB-3** | LOW -- grounded by both prior decision and live-code mismatch |
+| **CLI-3** `--all` should mean supported runtimes only | **SB-4** | LOW -- follows directly from the narrowed support contract |
+| **CLI-4** deprecated runtime flags should fail fast with guidance | **RR-3**, **Q2** | MEDIUM -- user-facing transition behavior still needs migration research |
+| **CB-2** update live source surfaces, not just installer code | **SB-4**, **CB-1** | LOW -- the stale live surfaces are directly evidenced |
+| **RR-2** add a mechanical regression for runtime scope | **SB-5**, **RR-1** | MEDIUM -- enforcement need is clear, declaration location remains open |
+| **DC-5** do not widen into historical-runtime taxonomy cleanup | **RR-4**, **G-3** | LOW -- firmly bounded by phase scope and governance |
+
+***
+
+## Context-Checker Verification Log
+
+**Checked:** 2026-04-21
+**Agent:** gsdr-context-checker
+
+### Typed Claim Verification
+
+| Claim | Type | Verification | Status | Issue |
+|-------|------|-------------|--------|-------|
+| SB-1 narrowed active support to Claude/Codex only | evidenced | cited | PASS | Citation resolved after tightening the line reference to include the explicit Claude/Codex user statement. |
+| SB-2 capability matrix already declares Claude/Codex as supported | evidenced | cited | PASS | -- |
+| SB-3 installer still treats Gemini/OpenCode as first-class targets | evidenced | cited | PASS | -- |
+| SB-4 installer support surface should match the current contract | decided | reasoned | PASS | Alternatives and rationale recorded. |
+| SB-5 supported-runtime scope should become machine-checkable | assumed | reasoned | PASS | Challenge protocol and supporting signal check recorded. |
+| CLI-1 installer help and README still advertise deprecated flags | evidenced | cited | PASS | -- |
+| CLI-2 `--all` still expands to four runtimes and chooser offers all four | evidenced | cited | PASS | -- |
+| CLI-3 `--all` should mean all supported runtimes only | decided | reasoned | PASS | Alternatives and rationale recorded. |
+| CLI-4 deprecated runtime flags should fail fast with guidance | assumed | reasoned | PASS | Challenge protocol recorded; uninstall compatibility remains explicitly open in Q2. |
+| CB-1 live source surfaces still reflect four-runtime assumptions | evidenced | cited | PASS | -- |
+| CB-2 phase should update load-bearing live authority surfaces | decided | reasoned | PASS | Alternatives and rationale recorded. |
+| CB-3 archives/history should not be mass-rewritten | governing | reasoned | PASS | Source and scope of governance recorded. |
+| CB-4 repo-local `.gemini/` / `.opencode/` outputs are disposable byproducts | assumed | reasoned | PASS | Challenge protocol recorded. |
+| RR-1 no current invariant ties installer targets to supported-runtime scope | evidenced | cited | PASS | -- |
+| RR-2 phase must add at least one mechanical runtime-scope regression | decided | reasoned | PASS | Alternatives and rationale recorded. |
+| RR-3 removing deprecated flags should be called out in v1.20.0 release messaging | assumed | reasoned | PASS | Challenge protocol recorded. |
+| RR-4 prefer the narrowest enforcement that closes scope drift | governing | reasoned | PASS | Source and scope of governance recorded. |
+| DC-1 source paths are canonical and runtime mirrors are outputs | evidenced | cited | PASS | Citation tightened to exact `AGENTS.md` lines. |
+| DC-2 Phase 59.1 is an urgent inserted installer-scope correction | evidenced | cited | PASS | -- |
+| DC-3 installer hotspot and main regression surfaces are `bin/install.js`, unit tests, and multi-runtime integration tests | evidenced | cited | PASS | Citation tightened to exact `AGENTS.md` lines. |
+| DC-4 capability matrix must stay aligned with runtime-support changes | evidenced | cited | PASS | -- |
+| DC-5 scope excludes retroactive cleanup of historical runtime identifiers | decided | reasoned | PASS | Alternatives and rationale recorded. |
+| DC-6 `.gitignore` omits `.gemini/` / `.opencode/` today | evidenced | cited | PASS | -- |
+| G-1 newer explicit support-scope sources outrank older four-runtime prose | governing | reasoned | PASS | Source and scope of governance recorded. |
+| G-2 unsupported runtime behavior must be explicit | governing | reasoned | PASS | Source and scope of governance recorded. |
+| G-3 keep the phase boundary tight to live installer authority surfaces | governing | reasoned | PASS | Source and scope of governance recorded. |
+| G-4 planning must include at least one declared-scope regression | stipulated | reasoned | PASS | Choice, calibration evidence, and reasonable range recorded. |
+| G-5 lingering four-runtime live claims must be treated as bugs or explicit deferrals | governing | reasoned | PASS | Source and scope of governance recorded. |
+
+### Untyped Claims Surfaced
+
+| Claim Text | Proposed Type | Location | Rationale |
+|-----------|---------------|----------|-----------|
+| Q1: Where should the canonical supported-runtime declaration live? | open | Open Questions, line 87 | Load-bearing unresolved research question that directly affects helper placement, test shape, and update burden; typed in CONTEXT as `[open:bare]`. |
+| Q2: What is the migration and cleanup contract for legacy Gemini/OpenCode users? | open | Open Questions, line 92 | Load-bearing unresolved question that directly constrains CLI failure behavior and cleanup scope; typed in CONTEXT as `[open:bare]`. |
+| Q3: Which live source documents must be corrected in Phase 59.1, and which should be explicitly left historical? | open | Open Questions, line 97 | Load-bearing unresolved inventory question that constrains patch scope and closeout discipline; typed in CONTEXT as `[open:bare]`. |
+
+### Dependency Chain Audit
+
+| Chain | Verdict |
+|-------|---------|
+| SB-4 -> SB-1, SB-2, SB-3 | PASS: decided claim rests on cited prior decision plus current-code drift evidence. |
+| CLI-3 -> SB-4 | PASS: low-vulnerability follow-on from a settled scope decision. |
+| CLI-4 -> RR-3, Q2 | WARN: supporting question existed only as untyped prose in CONTEXT; typed as `[open:bare]` during this check so the dependency chain is now explicit. |
+| CB-2 -> SB-4, CB-1 | PASS: decided scope correction is grounded in the narrowed support contract and directly cited drift evidence. |
+| RR-2 -> SB-5, RR-1 | WARN: recorded vulnerability was understated; corrected from MEDIUM to HIGH because a decided claim depends in part on an assumed claim while Q1 remains open. |
+| DC-5 -> RR-4, G-3 | PASS: low-vulnerability scope boundary rests on governing constraints. |
+| Unrecorded high-vulnerability chains | PASS: no additional unrecorded high-vulnerability chains surfaced beyond the Q2 typing gap and RR-2 vulnerability understatement. |
+
+### Summary
+
+- **Typed claims checked:** 28
+- **Pass:** 28 | **Warn:** 0 | **Fail:** 0
+- **Untyped claims surfaced:** 3
+- **Dependency vulnerabilities:** 2 found / 6 recorded
+- **Overall severity:** WARN

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-DISCUSSION-LOG.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-DISCUSSION-LOG.md
@@ -205,22 +205,10 @@
 - **Source:** The inserted phase exists precisely because contradictory live source claims were treated as harmless until the installer exposed them again
 - **Scope of governance:** Forces planner/executor closeout to account for remaining contradictions explicitly
 
-### Open Questions
-
-**[open] Q1: Where should the canonical supported-runtime declaration live?**
-- **What's been tried:** Read the installer, capability matrix, signal, and current tests to identify existing authority candidates
-- **Why unresolved:** The need for a single authority is clear, but the repo currently splits runtime knowledge across code, docs, and tests
-- **Research delegation:** Compare an installer-exported constant, an existing manifest/config surface, and a capability-reference-derived helper for duplication risk and testability
-
-**[open] Q2: What is the migration and cleanup contract for legacy Gemini/OpenCode users?**
-- **What's been tried:** Established that current install paths are publicly exposed and that the phase wants them removed from installer scope
-- **Why unresolved:** The repo has not yet answered whether uninstall/manual-cleanup compatibility should survive the install-path removal
-- **Research delegation:** Inspect uninstall code paths and release-note expectations to determine whether a cleanup-only escape hatch is warranted
-
-**[open] Q3: Which live source documents must be corrected in Phase 59.1, and which should be explicitly left historical?**
-- **What's been tried:** Identified README, PROJECT, capability matrix, installer help, and test surfaces as current live contradictions
-- **Why unresolved:** The exact cut line between "live authority" and "historical evidence" still needs a deliberate inventory rather than an intuitive sweep
-- **Research delegation:** Inventory present-tense runtime claims and sort them by authority and audience before task breakdown
+**[assumed:reasoned] RR-5: For Phase 59.1 planning, the supported-runtime declaration should live in a source-level authority consumed directly by installer code and regression tests, with user-facing docs mirroring that authority rather than defining it.**
+- **Challenge protocol:** If research finds a stronger existing manifest/config surface that already behaves as the real authority, the planner should use that instead and document why it is sufficiently load-bearing
+- **Evidence checked:** `.planning/knowledge/signals/get-shit-done-reflect/2026-04-21-installer-advertises-gemini-opencode-unsupported.md:69-73` identifies the lack of a machine-checkable authority as the structural cause; `get-shit-done/bin/lib/update-target.cjs` already shows the repo using source-level runtime helpers for narrow scope decisions
+- **Why reasonable:** A source-level authority is the narrowest way to couple installer code and tests without letting prose docs become the executable contract
 
 ### Claim Dependencies
 
@@ -228,14 +216,19 @@
 |-------|-----------|---------------|
 | **SB-4** installer support surface should be Claude+Codex only | **SB-1**, **SB-2**, **SB-3** | LOW -- grounded by both prior decision and live-code mismatch |
 | **CLI-3** `--all` should mean supported runtimes only | **SB-4** | LOW -- follows directly from the narrowed support contract |
-| **CLI-4** deprecated runtime flags should fail fast with guidance | **RR-3**, **Q2** | MEDIUM -- user-facing transition behavior still needs migration research |
+| **CLI-4** deprecated runtime flags should fail fast with guidance | **SB-4**, **RR-3** | MEDIUM -- user-facing transition behavior still depends on release/migration assumptions |
 | **CB-2** update live source surfaces, not just installer code | **SB-4**, **CB-1** | LOW -- the stale live surfaces are directly evidenced |
-| **RR-2** add a mechanical regression for runtime scope | **SB-5**, **RR-1** | MEDIUM -- enforcement need is clear, declaration location remains open |
+| **RR-2** add a mechanical regression for runtime scope | **RR-5**, **RR-1** | HIGH -- decided enforcement still depends on an assumed authority-location claim |
 | **DC-5** do not widen into historical-runtime taxonomy cleanup | **RR-4**, **G-3** | LOW -- firmly bounded by phase scope and governance |
 
 ***
 
 ## Context-Checker Verification Log
+
+### Post-checker revision
+
+- Cleared the three `[open]` items that would have triggered `plan-phase` GATE-09b by folding them into the existing planning assumptions already carried by `CLI-4`, `CB-2` / `CB-3`, and new claim `RR-5`
+- Preserved the checker's substantive warning: `RR-2` still rests on an assumed authority-location claim, so that dependency remains `HIGH` vulnerability until research validates the declaration surface
 
 **Checked:** 2026-04-21
 **Agent:** gsdr-context-checker
@@ -300,3 +293,21 @@
 - **Untyped claims surfaced:** 3
 - **Dependency vulnerabilities:** 2 found / 6 recorded
 - **Overall severity:** WARN
+
+### Re-verification after post-checker revision
+
+This note supersedes the prior WARN snapshot above. That earlier entry preserved the pre-revision state when `Q1`/`Q2`/`Q3` still existed as `[open]` claims in `59.1-CONTEXT.md`.
+
+**Checked:** 2026-04-21
+**Agent:** gsdr-context-checker
+
+### Updated Status
+
+| Area | Status | Note |
+|------|--------|------|
+| Typed claim verification | PASS | 29 typed claims checked; all cited file/line references still resolve and still support the claim text. |
+| Type/justification check | PASS | `decided` claims still record alternatives, `assumed` claims still record challenge protocols, `governing` claims still name provenance, and `G-4` still acknowledges its stipulated enforcement-floor choice. |
+| Untyped claim scan | PASS | No additional load-bearing untyped claims surfaced in the revised document. Remaining untyped prose is section scaffolding, reference inventory, or paraphrase already captured by typed claims. |
+| Dependency audit | PASS | All 6 recorded dependency chains still resolve to existing claims; no circular or missing chains found. `RR-2 -> RR-5` remains HIGH vulnerability, but that vulnerability is now explicitly and accurately recorded rather than hidden behind an `[open]` gap. |
+| Open-claim state | PASS | Current `59.1-CONTEXT.md` contains no `[open]` claims. |
+| Overall severity | PASS | Prior `Q1`/`Q2`/`Q3` open-claim WARN findings are obsolete after the post-checker revision. |

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-RESEARCH.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-RESEARCH.md
@@ -1,0 +1,329 @@
+# Phase 59.1: Drop Gemini and OpenCode from installer scope - Research
+
+**Researched:** 2026-04-21
+**Domain:** Installer runtime-scope authority, stale installer surfaces, and machine-checkable support invariants
+**Confidence:** MEDIUM
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- **SB-4:** [decided:reasoned] Phase 59.1 should make the installer's authoritative support surface match the current project support contract: Claude Code plus Codex CLI only.
+- **CLI-3:** [decided:reasoned] After Phase 59.1, `--all` should mean all supported runtimes only: Claude Code and Codex CLI.
+- **CB-2:** [decided:reasoned] Phase 59.1 should update load-bearing source surfaces that advertise or validate installer support scope: installer code, live docs/help text, regression tests, runtime-capability references, and `.gitignore`.
+- **RR-2:** [decided:reasoned] Phase 59.1 must add at least one regression surface that couples declared runtime support to installer behavior so future scope drift fails mechanically.
+- **DC-5:** [decided:reasoned] Phase 59.1 is about installer support scope, not retroactive normalization of historical runtime identifiers in KB entries, telemetry artifacts, or archived phase outputs.
+
+### Governing Constraints
+- **CB-3:** [governing:reasoned] Historical phase artifacts, archived audits, and old signals are evidence of how the project evolved; they should not be mass-rewritten just to make the history look cleaner.
+- **RR-4:** [governing:reasoned] The phase should prefer the narrowest enforcement that closes installer-scope drift; it must not balloon into a full runtime-taxonomy rewrite across unrelated measurement, KB, or archive surfaces.
+- **G-1:** [governing:reasoned] When live sources disagree, prioritize the newest explicit support-scope chain: the 2026-04-08 deliberation, the capability-matrix deprecation notice, and the 2026-04-21 signal/state insertion outrank older "4 runtimes supported" prose.
+- **G-2:** [governing:reasoned] Unsupported runtime behavior must be explicit. The phase should not silently install Claude/Codex when the user asked for Gemini/OpenCode, and it should not report success for unsupported installs.
+- **G-3:** [governing:reasoned] Keep the phase boundary tight: correct live installer authority surfaces and current docs/tests, but do not rewrite archives, telemetry schemas, or KB history just to harmonize wording.
+- **G-4:** [stipulated:reasoned] Planning must include at least one regression that compares installer target expansion against a declared supported-runtime set rather than relying on prose discipline alone.
+- **G-5:** [governing:reasoned] Any present-tense live source document that still claims active four-runtime support after 59.1 planning should be treated as an unfixed bug or an explicit named deferral, not as harmless drift.
+
+### Claude's Discretion
+- Exact helper placement for the supported-runtime authority once the declaration surface is chosen
+- Exact split between unit and integration coverage, as long as the supported-runtime invariant is mechanically enforced
+
+### Deferred Ideas (OUT OF SCOPE)
+- Full project-wide purge of every historical Gemini/OpenCode mention across archived phase artifacts, old audits, and telemetry/KB history — outside Phase 59.1's installer-scope boundary
+- Any future reintroduction of Gemini/OpenCode as community plugins or separately maintained adapters — would be its own roadmap item, not part of this corrective phase
+- Broader runtime-taxonomy cleanup outside installer scope (for example resume-work path examples, long-tail template enums, or historical compatibility echoes) unless planning proves a specific live source surface is still load-bearing for v1.20.0
+</user_constraints>
+
+## Summary
+
+[evidenced:cited] The live installer contract is still four-runtime in all the places that matter mechanically: flag parsing and runtime expansion in [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:68), help text in [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:229), the interactive chooser in [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:3181), unit smoke coverage in [tests/unit/install.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/unit/install.test.js:62), integration parity coverage in [tests/integration/multi-runtime.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/multi-runtime.test.js:470), KB `--all` install coverage in [tests/integration/cross-runtime-kb.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/cross-runtime-kb.test.js:93), public install docs in [README.md](/home/rookslog/workspace/projects/get-shit-done-reflect/README.md:78), and present-tense project framing in [.planning/PROJECT.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/PROJECT.md:5). A fresh temp-HOME smoke run on 2026-04-21 also confirmed that `--all --global` still creates `.gemini/` and `.config/opencode/`, and `--gemini --global` still succeeds.
+
+[evidenced:cited] RR-2 remains structurally vulnerable because there is no current machine-checkable source authority for "supported installer runtimes." The code duplicates runtime scope in module-level arrays inside [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:81), while tests duplicate it again in `SUPPORTED_RUNTIMES = ['claude', 'opencode', 'gemini', 'codex']` inside [tests/integration/multi-runtime.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/multi-runtime.test.js:1019). The closest repo-native precedent for solving this cleanly is the side-effect-free, importable authority pattern already used in [get-shit-done/bin/lib/update-target.cjs](/home/rookslog/workspace/projects/get-shit-done-reflect/get-shit-done/bin/lib/update-target.cjs:20), which `bin/install.js` itself already consumes.
+
+[assumed:reasoned] The narrowest durable fix is therefore: introduce one side-effect-free source helper that declares supported installer runtimes and legacy unsupported flags; make `bin/install.js` derive `--all`, explicit runtime validation, chooser options, and local/global dir examples from that helper; update the unit and integration suites to import the same authority; and demote docs plus capability-matrix prose to mirrors rather than sources of truth. This tightens RR-2 -> RR-5 from "assumed shared authority" to "single exported authority actually consumed by code and tests."
+
+**Primary recommendation:** Add a side-effect-free installer-runtime authority helper outside `bin/install.js`, make `--all` derive from it, make `--gemini`/`--opencode` and legacy installer `--both` fail explicitly, and rewrite the current four-runtime tests/docs to mirror that single authority.
+
+## Standard Stack
+
+### Core
+| Library | Version | Purpose | Why Standard |
+|---------|---------|---------|--------------|
+| Node.js | `>=22.5.0` | Runtime for installer and tests | Pinned by [package.json](/home/rookslog/workspace/projects/get-shit-done-reflect/package.json:17) and already used everywhere in this phase surface. |
+| Vitest | `^3.0.0` | Fast unit and integration regression coverage | Existing installer regression suites already run on it in [package.json](/home/rookslog/workspace/projects/get-shit-done-reflect/package.json:31). |
+| Side-effect-free helper module under `get-shit-done/bin/lib/` | repo source | Source authority shared by installer and tests | [evidenced:cited] This repo already uses this pattern for Codex install-target resolution in [get-shit-done/bin/lib/update-target.cjs](/home/rookslog/workspace/projects/get-shit-done-reflect/get-shit-done/bin/lib/update-target.cjs:254). |
+
+### Supporting
+| Library | Version | Purpose | When to Use |
+|---------|---------|---------|-------------|
+| `tmpdirTest` + subprocess `execSync` | repo helper + Node built-ins | Verify real installer side effects under temp HOME/config dirs | Use for CLI flag behavior, `--all` layout, and unsupported-flag exit behavior. |
+| `get-shit-done/references/capability-matrix.md` | current repo doc | Human-readable mirror of live runtime contract | Update after code authority changes; do not use as executable authority. |
+| `.planning/knowledge` signals | current KB | Blast-radius and regression-pattern evidence | Use to keep the phase narrow and avoid repeating prior installer mistakes. |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Side-effect-free helper module | Export a `SUPPORTED_INSTALL_RUNTIMES` constant from `bin/install.js` | Rejected: importing `bin/install.js` still evaluates top-level argv parsing and other installer globals, which keeps tests awkward and brittle. |
+| Side-effect-free helper module | Custom `package.json` metadata field | Rejected: still needs wrapper code, has no current consumers, and is farther from the existing install-helper pattern. |
+| Source-level helper | `capability-matrix.md` or `README.md` as authority | Rejected: prose is not machine-checkable and is exactly where drift already survived. |
+| Explicit error for installer `--both` | Silently remap `--both` to Claude + Codex | Rejected: old `--both` implicitly meant Claude + OpenCode; silent remap would violate the explicitness rule in G-2. |
+
+**Installation:**
+```bash
+npm install
+# No new dependencies recommended for Phase 59.1
+```
+
+## Architecture Patterns
+
+### Recommended Project Structure
+```text
+bin/install.js                             # CLI parsing, prompts, install/uninstall orchestration
+get-shit-done/bin/lib/runtime-support.cjs  # New source authority for supported installer runtimes
+get-shit-done/bin/lib/update-target.cjs    # Existing side-effect-free helper precedent
+tests/unit/install.test.js                 # Fast invariant checks + unsupported-flag subprocess smoke
+tests/integration/multi-runtime.test.js    # Supported-runtime install layout coverage
+tests/integration/cross-runtime-kb.test.js # `--all` KB/shared-path behavior for supported runtimes
+get-shit-done/references/capability-matrix.md
+README.md
+.planning/PROJECT.md
+.gitignore
+```
+
+### Pattern 1: Source-Level Runtime Authority Helper
+**What:** [assumed:reasoned] Put the installer support contract in one importable helper module that exposes supported runtimes, unsupported legacy flags, and `--all` expansion.
+**When to use:** Any code or test needs to know what installer scope is supported right now.
+**Example:**
+```javascript
+// Source pattern: get-shit-done/bin/lib/update-target.cjs exports side-effect-free helpers.
+const SUPPORTED_INSTALL_RUNTIMES = Object.freeze(['claude', 'codex']);
+const UNSUPPORTED_INSTALL_RUNTIMES = Object.freeze(['opencode', 'gemini']);
+const LEGACY_INSTALL_ALIASES = Object.freeze(['both']);
+
+function expandInstallSelection({ all = false, explicit = [] } = {}) {
+  if (all) return [...SUPPORTED_INSTALL_RUNTIMES];
+
+  const invalid = explicit.filter((runtime) =>
+    UNSUPPORTED_INSTALL_RUNTIMES.includes(runtime) || LEGACY_INSTALL_ALIASES.includes(runtime)
+  );
+  if (invalid.length > 0) {
+    throw new Error(
+      `Unsupported installer target: ${invalid.join(', ')}. Supported runtimes: claude, codex.`
+    );
+  }
+
+  return explicit.length > 0 ? explicit : ['claude'];
+}
+```
+
+### Pattern 2: Dual-Layer Regression Guard
+**What:** [assumed:reasoned] Use one fast unit-level invariant against the helper plus one subprocess install smoke that checks real directories.
+**When to use:** Any installer-scope change that affects `--all`, explicit runtime flags, or byproduct directories.
+**Example:**
+```javascript
+import { expect, it } from 'vitest';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import { execSync } from 'node:child_process';
+
+const {
+  SUPPORTED_INSTALL_RUNTIMES,
+  expandInstallSelection,
+} = require('../../get-shit-done/bin/lib/runtime-support.cjs');
+
+it('--all expands to the supported installer runtimes only', () => {
+  expect(expandInstallSelection({ all: true })).toEqual(SUPPORTED_INSTALL_RUNTIMES);
+});
+
+tmpdirTest('--all installs only supported runtimes', async ({ tmpdir }) => {
+  execSync(`node "${installScript}" --all --global`, {
+    env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: path.join(tmpdir, '.config') },
+    cwd: tmpdir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  await expect(fs.access(path.join(tmpdir, '.claude'))).resolves.toBeUndefined();
+  await expect(fs.access(path.join(tmpdir, '.codex'))).resolves.toBeUndefined();
+  await expect(fs.access(path.join(tmpdir, '.gemini'))).rejects.toBeTruthy();
+  await expect(fs.access(path.join(tmpdir, '.config', 'opencode'))).rejects.toBeTruthy();
+});
+```
+
+### Pattern 3: Docs Mirror the Helper, They Do Not Define It
+**What:** [evidenced:cited] README/help/capability-matrix/PROJECT copy should be derived from the same binary Claude/Codex support contract, not independently phrased.
+**When to use:** Any time the helper changes or installer user-facing language changes.
+**Example:**
+```text
+Supported installer runtimes: Claude Code and Codex CLI.
+`--all` installs both.
+`--gemini`, `--opencode`, and installer `--both` are unsupported and exit with migration guidance.
+```
+
+### Anti-Patterns to Avoid
+- **Exporting authority from `bin/install.js`:** The file parses argv at module scope, so importing it to discover runtime support keeps tests coupled to process-global state.
+- **Using prose as executable truth:** `README.md` and `capability-matrix.md` should mirror the helper, not compete with it.
+- **Rewriting archives/history:** The phase exists to correct live installer scope, not normalize every historical mention.
+- **Grepping `--both` blindly:** [tests/integration/cross-runtime-kb.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/cross-runtime-kb.test.js:714) uses `kb link show --both` for an unrelated CLI surface.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Supported installer scope | Ad hoc arrays in installer, tests, and docs | One exported runtime-support helper | [evidenced:cited] Drift already survived because scope was duplicated and prose-led. |
+| Unsupported runtime messaging | Separate error text branches for every legacy flag | One shared unsupported-target formatter/helper | Keeps `--gemini`, `--opencode`, and installer `--both` behavior aligned. |
+| Codex config-dir precedence | New inline Codex path resolution | `getCodexConfigDir()` from [update-target.cjs](/home/rookslog/workspace/projects/get-shit-done-reflect/get-shit-done/bin/lib/update-target.cjs:20) | Existing tested helper already handles explicit dir and env precedence. |
+| Runtime parity contract | Test-local `SUPPORTED_RUNTIMES` arrays | Import the same source authority the installer uses | Prevents the tests from silently preserving an obsolete four-runtime worldview. |
+
+**Key insight:** [assumed:reasoned] The mistake to avoid is not "custom code" in general; it is custom runtime-scope knowledge duplicated in multiple places. One executable authority plus a couple of narrow regression checks is enough for this phase.
+
+## Common Pitfalls
+
+### Pitfall 1: Fixing Help Text but Not Behavior
+**What goes wrong:** README/help text says Claude + Codex only, but `--all` or explicit legacy flags still install Gemini/OpenCode.
+**Why it happens:** Runtime scope is currently encoded in top-level arrays and chooser branches in [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:81) and [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:3193), not just the help text.
+**How to avoid:** Make help text derive from the same helper that drives runtime expansion and validation.
+**Warning signs:** `find "$TMPDIR" -maxdepth 2 -type d` still shows `.gemini` or `.config/opencode` after `--all`.
+
+### Pitfall 2: Leaving the Tests on the Old Four-Runtime Contract
+**What goes wrong:** Installer code narrows to Claude/Codex, but tests still expect all four runtimes and either fail noisily or get patched into new drift.
+**Why it happens:** Four-runtime constants and expectations are hard-coded in [tests/unit/install.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/unit/install.test.js:1925), [tests/integration/multi-runtime.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/multi-runtime.test.js:471), and [tests/integration/multi-runtime.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/multi-runtime.test.js:1019).
+**How to avoid:** Replace test-local runtime lists with imports from the new helper, then rewrite the integration expectations around supported runtimes plus explicit rejection tests for legacy flags.
+**Warning signs:** Any test still says "all 4 runtimes" or asserts `.gemini` / `.config/opencode` should exist after `--all`.
+
+### Pitfall 3: Keeping Dead Gemini/OpenCode Converter Exports as If They Were Live
+**What goes wrong:** The installer no longer supports Gemini/OpenCode, but exported converters and their unit suites remain in source and keep implying support.
+**Why it happens:** `convertClaudeToOpencodeFrontmatter`, `resolveOpencodeConfigPath`, and `convertClaudeToGeminiAgent` are directly exported from [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:3354) and directly tested in [tests/unit/install.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/unit/install.test.js:822) and [tests/unit/install.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/unit/install.test.js:2099).
+**How to avoid:** Make an explicit plan choice: delete these dead helpers/tests as part of support-surface correction, or name a very explicit deferral. Do not leave them silently.
+**Warning signs:** `rg "convertClaudeToGeminiAgent|convertClaudeToOpencodeFrontmatter" bin/install.js tests/unit/install.test.js` still returns live exports after phase closeout without a named deferral.
+
+### Pitfall 4: Breaking the Wrong `--both`
+**What goes wrong:** Cleanup aimed at the installer's hidden legacy `--both` flag accidentally breaks `gsd-tools kb link show --both`.
+**Why it happens:** The same flag spelling appears in an unrelated CLI surface in [tests/integration/cross-runtime-kb.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/cross-runtime-kb.test.js:714).
+**How to avoid:** Scope edits and grep patterns to installer surfaces (`bin/install.js`, installer tests, README/help), not global `--both` matches.
+**Warning signs:** KB parity tests start failing while installer tests pass.
+
+### Pitfall 5: Forgetting Local Byproduct Hygiene
+**What goes wrong:** The phase removes Gemini/OpenCode support but local verification still leaves unignored `.gemini/` or `.opencode/` directories in the repo root.
+**Why it happens:** [.gitignore](/home/rookslog/workspace/projects/get-shit-done-reflect/.gitignore:8) ignores `.claude/` and [.gitignore](/home/rookslog/workspace/projects/get-shit-done-reflect/.gitignore:36) ignores `.codex/`, but there is no parallel ignore coverage for `.gemini/` or `.opencode/`.
+**How to avoid:** Add defensive ignore rules as part of the live support-surface correction.
+**Warning signs:** `git status --short` shows runtime byproducts after installer smoke tests.
+
+## Code Examples
+
+Verified repo-native patterns for this phase:
+
+### Importable Source Authority
+```javascript
+// Source pattern: get-shit-done/bin/lib/update-target.cjs:20-27,254-302
+const {
+  SUPPORTED_INSTALL_RUNTIMES,
+  expandInstallSelection,
+  assertInstallerTargetSupported,
+} = require('../../get-shit-done/bin/lib/runtime-support.cjs');
+
+const runtimes = expandInstallSelection({
+  all: args.includes('--all'),
+  explicit: explicitRuntimeFlags,
+});
+```
+
+### Explicit Unsupported-Flag Smoke Test
+```javascript
+tmpdirTest('--gemini exits with unsupported-runtime guidance', async ({ tmpdir }) => {
+  expect(() => {
+    execSync(`node "${installScript}" --gemini --global`, {
+      env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: path.join(tmpdir, '.config') },
+      cwd: tmpdir,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  }).toThrow(/unsupported/i);
+});
+```
+
+### Supported-Only `--all` Directory Assertion
+```javascript
+tmpdirTest('--all installs Claude and Codex only', async ({ tmpdir }) => {
+  const configHome = path.join(tmpdir, '.config');
+
+  execSync(`node "${installScript}" --all --global`, {
+    env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+    cwd: tmpdir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  expect(fsSync.existsSync(path.join(tmpdir, '.claude'))).toBe(true);
+  expect(fsSync.existsSync(path.join(tmpdir, '.codex'))).toBe(true);
+  expect(fsSync.existsSync(path.join(tmpdir, '.gemini'))).toBe(false);
+  expect(fsSync.existsSync(path.join(configHome, 'opencode'))).toBe(false);
+});
+```
+
+## State of the Art
+
+| Old Approach | Current Approach | When Changed | Impact |
+|--------------|------------------|--------------|--------|
+| Four-runtime installer support by inertia | Binary Claude/Codex installer support | Support narrowing decided 2026-04-08; corrective phase inserted 2026-04-21 | Installer stops advertising or creating unsupported runtime installs. |
+| Prose-only deprecation notice | Source-level authority consumed by code and tests | Recommended in Phase 59.1 research on 2026-04-21 | RR-2 becomes machine-checkable instead of rhetorical. |
+| Four-runtime parity suite (`SUPPORTED_RUNTIMES = ['claude','opencode','gemini','codex']`) | Supported-runtime layout suite plus legacy-rejection smoke tests | Recommended in Phase 59.1 research on 2026-04-21 | Regression surface gets smaller and more meaningful. |
+
+**Deprecated/outdated:**
+- Installer help text and README examples that still advertise `--opencode`, `--gemini`, or `--all` as four-runtime installs.
+- Present-tense `4 runtimes supported` language in [.planning/PROJECT.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/PROJECT.md:211).
+- Four-runtime "supported" phrasing inside [get-shit-done/references/capability-matrix.md](/home/rookslog/workspace/projects/get-shit-done-reflect/get-shit-done/references/capability-matrix.md:102) even though the top notice already says only Claude and Codex are supported.
+- Hidden installer `--both` alias in [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js:76), which still encodes an obsolete Claude+OpenCode pair.
+
+## Open Questions
+
+### Resolved
+- **Where should the supported-runtime declaration live?** [assumed:reasoned] In a new side-effect-free helper module adjacent to existing install/update helpers, not in docs and not exported from `bin/install.js`.
+- **What should mechanically enforce RR-2?** [assumed:reasoned] One import-level invariant test plus subprocess smoke coverage for `--all`, explicit unsupported flags, and byproduct absence.
+- **Should this phase widen into general runtime-taxonomy cleanup?** [evidenced:cited] No. The locked scope limits work to live installer authority surfaces, current docs, regression tests, capability references, and `.gitignore`.
+- **What should happen to installer `--both`?** [assumed:reasoned] Treat it as explicit legacy error with migration guidance rather than silently remapping it.
+
+### Genuine Gaps
+| Question | Criticality | Recommendation |
+|----------|-------------|----------------|
+| Should uninstall still support targeted cleanup of pre-existing `.gemini` / `.opencode` installs? | Medium | Decide during planning. Keep only a narrow, explicit cleanup path if tests cover it; otherwise defer and document. |
+| Should dead Gemini/OpenCode converter exports/tests be deleted in the same phase or named as a follow-up? | Medium | Prefer delete-in-phase if they are installer-only and unreferenced elsewhere; otherwise create an explicit deferral instead of leaving them implied. |
+| Should `capability-matrix.md` keep deprecated columns or collapse to a binary table now? | Low | Keep the columns for historical reference, but rewrite present-tense "supported runtimes" wording to Claude/Codex only. Full matrix redesign is broader than 59.1. |
+
+### Still Open
+- No blocker remains on RR-2 -> RR-5 once the planner accepts the side-effect-free helper pattern. The remaining uncertainty is implementation slicing, not domain ambiguity.
+
+## Sources
+
+### Primary (HIGH confidence)
+- [.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-CONTEXT.md) - locked scope, RR-2 -> RR-5 vulnerability, and phase boundary
+- [.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-DISCUSSION-LOG.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-DISCUSSION-LOG.md) - decision rationale and dependency web
+- [.planning/STATE.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/STATE.md), [.planning/ROADMAP.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/ROADMAP.md), [.planning/REQUIREMENTS.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/REQUIREMENTS.md), [AGENTS.md](/home/rookslog/workspace/projects/get-shit-done-reflect/AGENTS.md) - live planning authority and repo rules
+- [bin/install.js](/home/rookslog/workspace/projects/get-shit-done-reflect/bin/install.js), [tests/unit/install.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/unit/install.test.js), [tests/integration/multi-runtime.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/multi-runtime.test.js), [tests/integration/cross-runtime-kb.test.js](/home/rookslog/workspace/projects/get-shit-done-reflect/tests/integration/cross-runtime-kb.test.js) - live installer behavior and regression surface
+- [get-shit-done/bin/lib/update-target.cjs](/home/rookslog/workspace/projects/get-shit-done-reflect/get-shit-done/bin/lib/update-target.cjs) - side-effect-free helper precedent
+- [get-shit-done/references/capability-matrix.md](/home/rookslog/workspace/projects/get-shit-done-reflect/get-shit-done/references/capability-matrix.md), [README.md](/home/rookslog/workspace/projects/get-shit-done-reflect/README.md), [.planning/PROJECT.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/PROJECT.md), [.gitignore](/home/rookslog/workspace/projects/get-shit-done-reflect/.gitignore) - stale live source surfaces that must mirror the new authority
+- Local smoke verification run on 2026-04-21: `HOME=$(mktemp -d) XDG_CONFIG_HOME="$HOME/.config" node bin/install.js --all --global` and `--gemini --global` - confirmed current installer still creates unsupported runtime outputs
+
+### Secondary (MEDIUM confidence)
+- [.planning/deliberations/drop-gemini-opencode-focus-codex.md](/home/rookslog/workspace/projects/get-shit-done-reflect/.planning/deliberations/drop-gemini-opencode-focus-codex.md) - the decisive narrowing from four active runtimes to Claude + Codex
+
+### Tertiary (LOW confidence)
+- None
+
+## Knowledge Applied
+
+| Entry | Type | Summary | Applied To |
+|-------|------|---------|------------|
+| sig-2026-04-21-installer-advertises-gemini-opencode-unsupported | signal | Lack of machine-checkable runtime authority let four-runtime drift survive a two-runtime decision | Summary, Architecture Patterns, Open Questions |
+| sig-2026-02-23-installer-clobbers-force-tracked-files | signal | Installer is high-blast-radius whole-directory machinery; phase must stay narrow and verified | Common Pitfalls, verification strategy |
+| sig-2026-03-06-installer-file-churn-hotspot | signal | `bin/install.js` and installer tests are volatility hotspots | Standard Stack, Common Pitfalls |
+| sig-2026-03-20-cross-runtime-upgrade-install-and-kb-drift | signal | Source-level helper/preflight authority is a better pattern than prose-led runtime drift handling | Architecture Patterns |
+| sig-2026-04-21-plan-59-05-established-cross-runtime-parity-tests | signal | Narrow parity tests that lock real behavior are a proven good pattern in this repo | Code Examples, Architecture Patterns |
+
+No existing spike fully answered Phase 59.1's core question. `001-runtime-capability-verification` is adjacent, but it validates runtime capability claims rather than installer support-scope authority, so it did not eliminate the need for this phase research.
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack: HIGH - local package metadata, test stack, and helper precedents are directly inspectable.
+- Architecture: MEDIUM - the recommended helper placement is reasoned from existing repo patterns rather than already implemented.
+- Pitfalls: HIGH - backed by current source inspection, KB signals, and live smoke verification.
+
+**Research date:** 2026-04-21
+**Valid until:** 2026-04-28 or until `bin/install.js` / installer tests materially change

--- a/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-VERIFICATION.md
+++ b/.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-VERIFICATION.md
@@ -1,0 +1,77 @@
+---
+phase: 59.1-drop-gemini-and-opencode-from-installer-scope
+verified: 2026-04-21T09:09:58Z
+status: passed
+score: 6/6 must-haves verified
+---
+
+# Phase 59.1: Drop Gemini and OpenCode from installer scope Verification Report
+
+**Phase Goal:** Narrow the installer's live support surface to Claude Code + Codex CLI only, make `--all` mean supported runtimes only, explicitly reject Gemini/OpenCode installer flags with migration guidance, align the live docs/help/matrix/changelog surfaces to that contract, and keep the phase narrow rather than rewriting historical archives or KB history.
+**Verified:** 2026-04-21T09:09:58Z
+**Status:** passed
+**Re-verification:** No — initial verification
+
+## Goal Achievement
+
+### Observable Truths
+
+| # | Truth | Status | Evidence |
+| --- | --- | --- | --- |
+| 1 | Installer runtime support is declared once in a side-effect-free source helper and consumed by installer code plus regressions. | ✓ VERIFIED | `get-shit-done/bin/lib/runtime-support.cjs:3-19` defines only `claude` and `codex`; `bin/install.js:8-17` imports it; `tests/unit/install.test.js:35-37`, `tests/integration/multi-runtime.test.js:10-16`, and `tests/integration/cross-runtime-kb.test.js:15-18` consume the same authority. |
+| 2 | `--all` now means supported runtimes only, and the installer prompt/help only offers Claude Code, Codex CLI, or all supported runtimes. | ✓ VERIFIED | `bin/install.js:199-200` advertises only `--claude`, `--codex`, and supported-only `--all`; `bin/install.js:2480-2490` shows the interactive chooser limited to Claude/Codex/all-supported; temp-HOME smoke run created `.claude` + `.codex` and did not create `.gemini` or `.config/opencode`. |
+| 3 | `--gemini`, `--opencode`, and legacy installer `--both` fail fast with explicit migration guidance instead of silently installing. | ✓ VERIFIED | `runtime-support.cjs:44-56` formats the unsupported-runtime guidance; `bin/install.js:2588-2590` exits non-zero on `runtimeSelectionError`; temp-HOME smoke run for `--gemini --global` exited `1` and printed the migration guidance. |
+| 4 | Mechanical regressions couple the declared installer-runtime authority to real behavior, so scope drift fails structurally. | ✓ VERIFIED | `tests/unit/install.test.js:35-110` asserts helper-driven `--all` plus unsupported-flag rejection; `tests/integration/multi-runtime.test.js:67-124` and `tests/integration/cross-runtime-kb.test.js:24-44` assert supported-only outputs; `npx vitest run tests/unit/install.test.js tests/integration/multi-runtime.test.js tests/integration/cross-runtime-kb.test.js --reporter=dot` passed with `266/266` tests green. |
+| 5 | `.gitignore`, README/help text, live project framing, capability-matrix wording, and changelog all align with the new installer contract. | ✓ VERIFIED | `.gitignore:8-11` ignores `.gemini/` and `.opencode/`; `README.md:78-109` documents only Claude/Codex/all-supported; `.planning/PROJECT.md:5,23` names only Claude Code + Codex CLI as active support; `get-shit-done/references/capability-matrix.md:18-24` states Gemini/OpenCode are deprecated references and installer flags now fail; `CHANGELOG.md:7-10` records the breaking change. Greps found no present-tense stale README/PROJECT claims. |
+| 6 | The phase stayed narrow and did not rewrite historical archives/KB history; it is sufficient to remediate the triggering installer-drift signal in the live codebase. | ✓ VERIFIED | Phase commits touched only `runtime-support.cjs`, `bin/install.js`, installer tests, `.gitignore`, `README.md`, `.planning/PROJECT.md`, `capability-matrix.md`, and `CHANGELOG.md`; no archive, roadmap, requirements, or historical KB files were rewritten. The triggering signal condition described in `.planning/knowledge/signals/get-shit-done-reflect/2026-04-21-installer-advertises-gemini-opencode-unsupported.md` is no longer reproducible in the installer. |
+
+**Score:** 6/6 truths verified
+
+### Required Artifacts
+
+| Artifact | Expected | Status | Details |
+| --- | --- | --- | --- |
+| `get-shit-done/bin/lib/runtime-support.cjs` | Canonical supported-installer-runtime declaration and guidance helpers | ✓ VERIFIED | Exists, substantive, and exports the shared Claude/Codex-only authority plus unsupported-target messaging. |
+| `bin/install.js` | Installer behavior derived from the shared authority | ✓ VERIFIED | Exists, imports the helper, uses it for help text, chooser options, runtime validation, and unsupported-target failures. |
+| `tests/unit/install.test.js` | Fast invariant and unsupported-flag smoke coverage | ✓ VERIFIED | Exists and is substantive. `gsd-tools verify artifacts` reported a literal-pattern miss (`"unsupported runtime"`), but manual review of lines `35-110` plus the passing Vitest run confirm the behavior is covered. |
+| `.gitignore` | Ignore unsupported-runtime byproducts | ✓ VERIFIED | `.gemini/` and `.opencode/` entries are present. |
+| `tests/integration/multi-runtime.test.js` | Supported-only installer layout and parity coverage | ✓ VERIFIED | Imports shared authority, verifies only supported runtimes, and asserts unsupported directories are absent. |
+| `tests/integration/cross-runtime-kb.test.js` | Supported-only `--all` KB fixture coverage | ✓ VERIFIED | Uses shared authority and asserts `.gemini` / `.opencode` absence before KB checks. |
+| `README.md` | Public install examples aligned to supported-only contract | ✓ VERIFIED | Non-interactive examples now cover Claude, Codex, and supported-only `--all` only. |
+| `.planning/PROJECT.md` | Live project framing aligned to active runtime support | ✓ VERIFIED | Present-tense product framing names Claude Code + OpenAI Codex CLI only. |
+| `get-shit-done/references/capability-matrix.md` | Capability reference aligned to supported-only installer behavior | ✓ VERIFIED | Preserves deprecated reference columns while explicitly stating only Claude/Codex are supported and legacy installer flags fail. |
+| `CHANGELOG.md` | Unreleased note for the installer-scope breaking change | ✓ VERIFIED | Unreleased section records the supported-only contract and legacy-flag failure behavior. |
+
+### Key Link Verification
+
+| From | To | Via | Status | Details |
+| --- | --- | --- | --- | --- |
+| `get-shit-done/bin/lib/runtime-support.cjs` | `bin/install.js` | Shared import for runtime validation, `--all`, and menu construction | ✓ VERIFIED | `gsd-tools verify key-links` passed; import and use are visible at `bin/install.js:8-17`, `103-113`, `199-200`, and `2480-2490`. |
+| `tests/unit/install.test.js` | `get-shit-done/bin/lib/runtime-support.cjs` | Unit tests import the installer authority directly | ✓ VERIFIED | `gsd-tools verify key-links` passed; direct import at `tests/unit/install.test.js:15` and invariant at `35-37`. |
+| `tests/integration/multi-runtime.test.js` | `get-shit-done/bin/lib/runtime-support.cjs` | Integration suite imports the same authority instead of a local runtime list | ✓ VERIFIED | `gsd-tools verify key-links` passed; import at `tests/integration/multi-runtime.test.js:10-13`, behavior at `108-124`. |
+| `tests/integration/cross-runtime-kb.test.js` | `bin/install.js` | Shared-KB tests run `bin/install.js --all --global` and assert supported-only outputs | ✓ VERIFIED | `gsd-tools verify key-links` passed; install helper at `tests/integration/cross-runtime-kb.test.js:36-44`. |
+| `README.md` | `bin/install.js` | Public install examples mirror supported-only flags and `--all` semantics | ✓ VERIFIED | `gsd-tools verify key-links` passed; README examples match current help surface. |
+| `get-shit-done/references/capability-matrix.md` | `get-shit-done/bin/lib/runtime-support.cjs` | Capability wording mirrors the canonical supported-runtime contract | ✓ VERIFIED | `gsd-tools verify key-links` passed; matrix deprecation notice aligns with the helper and installer smoke behavior. |
+
+### Requirements Coverage
+
+| Requirement | Status | Blocking Issue |
+| --- | --- | --- |
+| Phase-specific rows in `.planning/REQUIREMENTS.md` | N/A | `REQUIREMENTS.md` has no dedicated Phase 59.1 rows; per the user scope note and placeholder roadmap entry, verification used the `.planning/STATE.md` insertion note, `59.1-CONTEXT.md`, and the three plans' `must_haves` as authority. |
+
+### Anti-Patterns Found
+
+| File | Line | Pattern | Severity | Impact |
+| --- | --- | --- | --- | --- |
+| None | - | No `TODO`/`FIXME`/placeholder markers detected in phase-touched live files | - | No blocker or warning anti-patterns found in the verified surface. |
+
+### Gaps Summary
+
+No goal-blocking gaps found. The installer helper, CLI behavior, interactive chooser, regression coverage, docs/help text, `.gitignore`, capability matrix, and changelog all reflect the Claude/Codex-only contract, and the phase touched only the intended live surfaces.
+
+One bookkeeping note: the triggering signal file remains `status: active` in the knowledge base, but the live installer condition described by that signal is no longer reproducible. That reads as lifecycle reconciliation lag rather than a failure of the Phase 59.1 goal itself.
+
+---
+
+_Verified: 2026-04-21T09:09:58Z_
+_Verifier: Claude (gsdr-verifier)_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ For upstream GSD changelog, see [GSD Changelog](https://github.com/glittercowboy
 
 ## [Unreleased]
 
+### Changed
+- Installer support is now limited to Claude Code and Codex CLI. `--all` installs supported runtimes only, while `--gemini`, `--opencode`, and the legacy installer `--both` flag now fail with migration guidance instead of installing unsupported runtimes.
+
 ## [1.19.7] - 2026-04-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npx get-shit-done-reflect-cc
 ```
 
 The installer prompts you to choose:
-1. **Runtime** -- Claude Code, OpenCode, Gemini, or all
+1. **Runtime** -- Claude Code, Codex CLI, or all supported runtimes
 2. **Location** -- Global (all projects) or local (current project only)
 
 Verify with `/gsd:help` inside your chosen runtime.
@@ -97,18 +97,16 @@ npx get-shit-done-reflect-cc@latest
 npx get-shit-done-reflect-cc --claude --global
 npx get-shit-done-reflect-cc --claude --local
 
-# OpenCode
-npx get-shit-done-reflect-cc --opencode --global
+# Codex CLI
+npx get-shit-done-reflect-cc --codex --global
+npx get-shit-done-reflect-cc --codex --local
 
-# Gemini CLI
-npx get-shit-done-reflect-cc --gemini --global
-
-# All runtimes
+# All supported runtimes
 npx get-shit-done-reflect-cc --all --global
 ```
 
 Use `--global` (`-g`) or `--local` (`-l`) to skip the location prompt.
-Use `--claude`, `--opencode`, `--gemini`, or `--all` to skip the runtime prompt.
+Use `--claude`, `--codex`, or `--all` to skip the runtime prompt.
 
 </details>
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -7,6 +7,15 @@ const readline = require('readline');
 const crypto = require('crypto');
 const { execSync } = require('child_process');
 const { getCodexConfigDir } = require('../get-shit-done/bin/lib/update-target.cjs');
+const {
+  INSTALLER_RUNTIME_METADATA,
+  SUPPORTED_INSTALLER_RUNTIMES,
+  UNSUPPORTED_INSTALLER_TARGETS,
+  getInstallerRuntimeMetadata,
+  getInstallerRuntimeLabel,
+  expandInstallerRuntimeSelection,
+  formatUnsupportedRuntimeMessage,
+} = require('../get-shit-done/bin/lib/runtime-support.cjs');
 
 // Colors
 const cyan = '\x1b[36m';
@@ -69,100 +78,62 @@ const pkg = require('../package.json');
 const args = process.argv.slice(2);
 const hasGlobal = args.includes('--global') || args.includes('-g');
 const hasLocal = args.includes('--local') || args.includes('-l');
-const hasOpencode = args.includes('--opencode');
 const hasClaude = args.includes('--claude');
-const hasGemini = args.includes('--gemini');
 const hasCodex = args.includes('--codex');
-const hasBoth = args.includes('--both'); // Legacy flag, keeps working
+const hasOpencode = args.includes('--opencode');
+const hasGemini = args.includes('--gemini');
+const hasBoth = args.includes('--both');
 const hasAll = args.includes('--all');
 const hasUninstall = args.includes('--uninstall') || args.includes('-u');
 
-// Runtime selection - can be set by flags or interactive prompt
+const explicitRuntimeTargets = [];
+if (hasClaude) explicitRuntimeTargets.push('claude');
+if (hasCodex) explicitRuntimeTargets.push('codex');
+if (hasOpencode) explicitRuntimeTargets.push('opencode');
+if (hasGemini) explicitRuntimeTargets.push('gemini');
+if (hasBoth) explicitRuntimeTargets.push('both');
+
+const unsupportedInstallerTargets = explicitRuntimeTargets.filter((runtime) =>
+  UNSUPPORTED_INSTALLER_TARGETS.includes(runtime)
+);
+
 let selectedRuntimes = [];
-if (hasAll) {
-  selectedRuntimes = ['claude', 'opencode', 'gemini', 'codex'];
-} else if (hasBoth) {
-  selectedRuntimes = ['claude', 'opencode'];
-} else {
-  if (hasOpencode) selectedRuntimes.push('opencode');
-  if (hasClaude) selectedRuntimes.push('claude');
-  if (hasGemini) selectedRuntimes.push('gemini');
-  if (hasCodex) selectedRuntimes.push('codex');
+let runtimeSelectionError = null;
+
+try {
+  selectedRuntimes = expandInstallerRuntimeSelection({
+    all: hasAll,
+    explicit: explicitRuntimeTargets,
+  });
+} catch (error) {
+  runtimeSelectionError = error;
+}
+
+if (!runtimeSelectionError && unsupportedInstallerTargets.length > 0) {
+  runtimeSelectionError = new Error(formatUnsupportedRuntimeMessage(unsupportedInstallerTargets));
 }
 
 // Helper to get directory name for a runtime (used for local/project installs)
 function getDirName(runtime) {
-  if (runtime === 'opencode') return '.opencode';
-  if (runtime === 'gemini') return '.gemini';
-  if (runtime === 'codex') return '.codex';
-  return '.claude';
-}
-
-/**
- * Get the global config directory for OpenCode
- * OpenCode follows XDG Base Directory spec and uses ~/.config/opencode/
- * Priority: OPENCODE_CONFIG_DIR > dirname(OPENCODE_CONFIG) > XDG_CONFIG_HOME/opencode > ~/.config/opencode
- */
-function getOpencodeGlobalDir() {
-  // 1. Explicit OPENCODE_CONFIG_DIR env var
-  if (process.env.OPENCODE_CONFIG_DIR) {
-    return expandTilde(process.env.OPENCODE_CONFIG_DIR);
+  const metadata = getInstallerRuntimeMetadata(runtime);
+  if (!metadata) {
+    throw new Error(formatUnsupportedRuntimeMessage([runtime]));
   }
-  
-  // 2. OPENCODE_CONFIG env var (use its directory)
-  if (process.env.OPENCODE_CONFIG) {
-    return path.dirname(expandTilde(process.env.OPENCODE_CONFIG));
-  }
-  
-  // 3. XDG_CONFIG_HOME/opencode
-  if (process.env.XDG_CONFIG_HOME) {
-    return path.join(expandTilde(process.env.XDG_CONFIG_HOME), 'opencode');
-  }
-  
-  // 4. Default: ~/.config/opencode (XDG default)
-  return path.join(os.homedir(), '.config', 'opencode');
-}
-
-/**
- * Resolve the OpenCode config file path, preferring .jsonc when it exists.
- * @param {string} configDir - The OpenCode config directory
- * @returns {string} Path to opencode.jsonc (if exists) or opencode.json (fallback)
- */
-function resolveOpencodeConfigPath(configDir) {
-  const jsoncPath = path.join(configDir, 'opencode.jsonc');
-  if (fs.existsSync(jsoncPath)) {
-    return jsoncPath;
-  }
-  return path.join(configDir, 'opencode.json');
+  return metadata.dirName;
 }
 
 /**
  * Get the global config directory for a runtime
- * @param {string} runtime - 'claude', 'opencode', or 'gemini'
+ * @param {string} runtime - 'claude' or 'codex'
  * @param {string|null} explicitDir - Explicit directory from --config-dir flag
  */
 function getGlobalDir(runtime, explicitDir = null) {
-  if (runtime === 'opencode') {
-    // For OpenCode, --config-dir overrides env vars
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    return getOpencodeGlobalDir();
-  }
-  
-  if (runtime === 'gemini') {
-    // Gemini: --config-dir > GEMINI_CONFIG_DIR > ~/.gemini
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.GEMINI_CONFIG_DIR) {
-      return expandTilde(process.env.GEMINI_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.gemini');
-  }
-
   if (runtime === 'codex') {
     return getCodexConfigDir(explicitDir, process.env, os.homedir());
+  }
+
+  if (runtime !== 'claude') {
+    throw new Error(formatUnsupportedRuntimeMessage([runtime]));
   }
 
   // Claude Code: --config-dir > CLAUDE_CONFIG_DIR > ~/.claude
@@ -226,7 +197,7 @@ if (require.main === module) {
   console.log(banner);
 
   if (hasHelp) {
-    console.log(`  ${yellow}Usage:${reset} npx get-shit-done-reflect-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--codex${reset}                   Install for Codex CLI only\n    ${cyan}--all${reset}                     Install for all 4 runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-reflect-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-reflect-cc --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx get-shit-done-reflect-cc --gemini --global\n\n    ${dim}# Install for Codex CLI globally${reset}\n    npx get-shit-done-reflect-cc --codex --global\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx get-shit-done-reflect-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-reflect-cc --claude --global --config-dir ~/.claude-bc\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-reflect-cc --claude --local\n\n    ${dim}# Uninstall GSD from Claude Code globally${reset}\n    npx get-shit-done-reflect-cc --claude --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / GEMINI_CONFIG_DIR / CODEX_CONFIG_DIR environment variables.\n`);
+    console.log(`  ${yellow}Usage:${reset} npx get-shit-done-reflect-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--codex${reset}                   Install for Codex CLI only\n    ${cyan}--all${reset}                     Install for all supported runtimes (${SUPPORTED_INSTALLER_RUNTIMES.join(', ')})\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-reflect-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-reflect-cc --claude --global\n\n    ${dim}# Install for Codex CLI globally${reset}\n    npx get-shit-done-reflect-cc --codex --global\n\n    ${dim}# Install for all supported runtimes globally${reset}\n    npx get-shit-done-reflect-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-reflect-cc --claude --global --config-dir ~/.claude-bc\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-reflect-cc --claude --local\n\n    ${dim}# Uninstall GSD from Claude Code globally${reset}\n    npx get-shit-done-reflect-cc --claude --global --uninstall\n\n  ${yellow}Notes:${reset}\n    Unsupported legacy flags ${cyan}--opencode${reset}, ${cyan}--gemini${reset}, and ${cyan}--both${reset} now exit with migration guidance.\n    The --config-dir option takes priority over CLAUDE_CONFIG_DIR / CODEX_CONFIG_DIR environment variables.\n`);
     process.exit(0);
   }
 }
@@ -491,7 +462,7 @@ const attributionCache = new Map();
 
 /**
  * Get commit attribution setting for a runtime
- * @param {string} runtime - 'claude', 'opencode', or 'gemini'
+ * @param {string} runtime - 'claude' or 'codex'
  * @returns {null|undefined|string} null = remove, undefined = keep default, string = custom
  */
 function getCommitAttribution(runtime) {
@@ -502,20 +473,7 @@ function getCommitAttribution(runtime) {
 
   let result;
 
-  if (runtime === 'opencode') {
-    const config = readSettings(resolveOpencodeConfigPath(getGlobalDir('opencode', null)));
-    result = config.disable_ai_attribution === true ? null : undefined;
-  } else if (runtime === 'gemini') {
-    // Gemini: check gemini settings.json for attribution config
-    const settings = readSettings(path.join(getGlobalDir('gemini', explicitConfigDir), 'settings.json'));
-    if (!settings.attribution || settings.attribution.commit === undefined) {
-      result = undefined;
-    } else if (settings.attribution.commit === '') {
-      result = null;
-    } else {
-      result = settings.attribution.commit;
-    }
-  } else if (runtime === 'codex') {
+  if (runtime === 'codex') {
     // Codex CLI: no settings.json, keep default attribution
     result = undefined;
   } else {
@@ -555,53 +513,6 @@ function processAttribution(content, attribution) {
 }
 
 /**
- * Convert Claude Code frontmatter to opencode format
- * - Converts 'allowed-tools:' array to 'permission:' object
- * @param {string} content - Markdown file content with YAML frontmatter
- * @returns {string} - Content with converted frontmatter
- */
-// Color name to hex mapping for opencode compatibility
-const colorNameToHex = {
-  cyan: '#00FFFF',
-  red: '#FF0000',
-  green: '#00FF00',
-  blue: '#0000FF',
-  yellow: '#FFFF00',
-  magenta: '#FF00FF',
-  orange: '#FFA500',
-  purple: '#800080',
-  pink: '#FFC0CB',
-  white: '#FFFFFF',
-  black: '#000000',
-  gray: '#808080',
-  grey: '#808080',
-};
-
-// Tool name mapping from Claude Code to OpenCode
-// OpenCode uses lowercase tool names; special mappings for renamed tools
-const claudeToOpencodeTools = {
-  AskUserQuestion: 'question',
-  SlashCommand: 'skill',
-  TodoWrite: 'todowrite',
-  WebFetch: 'webfetch',
-  WebSearch: 'websearch',  // Plugin/MCP - keep for compatibility
-};
-
-// Tool name mapping from Claude Code to Gemini CLI
-// Gemini CLI uses snake_case built-in tool names
-const claudeToGeminiTools = {
-  Read: 'read_file',
-  Write: 'write_file',
-  Edit: 'replace',
-  Bash: 'run_shell_command',
-  Glob: 'glob',
-  Grep: 'search_file_content',
-  WebSearch: 'google_web_search',
-  WebFetch: 'web_fetch',
-  TodoWrite: 'write_todos',
-  AskUserQuestion: 'ask_user',
-};
-
 // Tool name mapping from Claude Code to Codex CLI
 // Codex CLI uses snake_case built-in tool names (codex-rs)
 const claudeToCodexTools = {
@@ -618,57 +529,6 @@ const claudeToCodexTools = {
   TodoWrite: 'update_plan',
   SlashCommand: null,
 };
-
-/**
- * Convert a Claude Code tool name to OpenCode format
- * - Applies special mappings (AskUserQuestion -> question, etc.)
- * - Converts to lowercase (except MCP tools which keep their format)
- */
-function convertToolName(claudeTool) {
-  // Check for special mapping first
-  if (claudeToOpencodeTools[claudeTool]) {
-    return claudeToOpencodeTools[claudeTool];
-  }
-  // MCP tools (mcp__*) keep their format
-  if (claudeTool.startsWith('mcp__')) {
-    return claudeTool;
-  }
-  // Default: convert to lowercase
-  return claudeTool.toLowerCase();
-}
-
-/**
- * Convert a Claude Code tool name to Gemini CLI format
- * - Applies Claude→Gemini mapping (Read→read_file, Bash→run_shell_command, etc.)
- * - Filters out MCP tools (mcp__*) — they are auto-discovered at runtime in Gemini
- * - Filters out Task — agents are auto-registered as tools in Gemini
- * @returns {string|null} Gemini tool name, or null if tool should be excluded
- */
-function convertGeminiToolName(claudeTool) {
-  // MCP tools: preserve as-is — Gemini CLI supports MCP servers
-  if (claudeTool.startsWith('mcp__')) {
-    return claudeTool;
-  }
-  // Task: exclude — agents are auto-registered as callable tools
-  if (claudeTool === 'Task') {
-    return null;
-  }
-  // Check for explicit mapping
-  if (claudeToGeminiTools[claudeTool]) {
-    return claudeToGeminiTools[claudeTool];
-  }
-  // Default: lowercase
-  return claudeTool.toLowerCase();
-}
-
-/**
- * Strip HTML <sub> tags for Gemini CLI output
- * Terminals don't support subscript — Gemini renders these as raw HTML.
- * Converts <sub>text</sub> to italic *(text)* for readable terminal output.
- */
-function stripSubTags(content) {
-  return content.replace(/<sub>(.*?)<\/sub>/g, '*($1)*');
-}
 
 /**
  * Extract YAML frontmatter and body from markdown content.
@@ -700,244 +560,6 @@ function extractFrontmatterField(frontmatter, fieldName) {
   const match = frontmatter.match(regex);
   if (!match) return null;
   return match[1].trim().replace(/^['"]|['"]$/g, '');
-}
-
-/**
- * Convert Claude Code agent frontmatter to Gemini CLI format
- * Gemini agents use .md files with YAML frontmatter, same as Claude,
- * but with different field names and formats:
- * - tools: must be a YAML array (not comma-separated string)
- * - tool names: must use Gemini built-in names (read_file, not Read)
- * - color: must be removed (causes validation error)
- * - mcp__* tools: preserved as-is (Gemini CLI supports MCP servers)
- */
-function convertClaudeToGeminiAgent(content) {
-  const { frontmatter, body } = extractFrontmatterAndBody(content);
-  if (!frontmatter) return content;
-
-  const lines = frontmatter.split('\n');
-  const newLines = [];
-  let inAllowedTools = false;
-  let inSkippedArrayField = false;
-  const tools = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    // Skip continuation lines of a stripped array field (e.g., skills:)
-    if (inSkippedArrayField) {
-      if (!trimmed || trimmed.startsWith('- ')) {
-        continue;
-      }
-      inSkippedArrayField = false;
-    }
-
-    // Convert allowed-tools YAML array to tools list
-    if (trimmed.startsWith('allowed-tools:')) {
-      inAllowedTools = true;
-      continue;
-    }
-
-    // Handle inline tools: field (comma-separated string)
-    if (trimmed.startsWith('tools:')) {
-      const toolsValue = trimmed.substring(6).trim();
-      if (toolsValue) {
-        const parsed = toolsValue.split(',').map(t => t.trim()).filter(t => t);
-        for (const t of parsed) {
-          const mapped = convertGeminiToolName(t);
-          if (mapped) tools.push(mapped);
-        }
-      } else {
-        // tools: with no value means YAML array follows
-        inAllowedTools = true;
-      }
-      continue;
-    }
-
-    // Strip color field (not supported by Gemini CLI, causes validation error)
-    if (trimmed.startsWith('color:')) continue;
-
-    // Strip skills field (not supported by Gemini CLI)
-    if (trimmed.startsWith('skills:')) {
-      inSkippedArrayField = true;
-      continue;
-    }
-
-    // Collect allowed-tools/tools array items
-    if (inAllowedTools) {
-      if (trimmed.startsWith('- ')) {
-        const mapped = convertGeminiToolName(trimmed.substring(2).trim());
-        if (mapped) tools.push(mapped);
-        continue;
-      } else if (trimmed && !trimmed.startsWith('-')) {
-        inAllowedTools = false;
-      }
-    }
-
-    if (!inAllowedTools) {
-      newLines.push(line);
-    }
-  }
-
-  // Add tools as YAML array (Gemini requires array format)
-  if (tools.length > 0) {
-    newLines.push('tools:');
-    for (const tool of tools) {
-      newLines.push(`  - ${tool}`);
-    }
-  }
-
-  const newFrontmatter = newLines.join('\n').trim();
-  // Apply tool name replacement to body text (same pattern as Codex converter)
-  let processedBody = stripSubTags(body);
-  for (const [claudeTool, geminiTool] of Object.entries(claudeToGeminiTools)) {
-    processedBody = processedBody.replace(new RegExp(`\\b${claudeTool}\\b`, 'g'), geminiTool);
-  }
-  // Escape ${VAR} patterns for Gemini CLI compatibility.
-  // Gemini's templateString() treats ${word} as template variables and throws
-  // "Template validation failed" when they can't be resolved. Removing braces
-  // ($PHASE instead of ${PHASE}) is equivalent bash syntax.
-  const escapedBody = processedBody.replace(/\$\{(\w+)\}/g, '$$$1');
-  return `---\n${newFrontmatter}\n---${escapedBody}`;
-}
-
-function convertClaudeToOpencodeFrontmatter(content, { isAgent = false } = {}) {
-  // Replace tool name references in content (applies to all files)
-  let convertedContent = content;
-  convertedContent = convertedContent.replace(/\bAskUserQuestion\b/g, 'question');
-  convertedContent = convertedContent.replace(/\bSlashCommand\b/g, 'skill');
-  convertedContent = convertedContent.replace(/\bTodoWrite\b/g, 'todowrite');
-  // Replace /gsd:command with /gsd-command for opencode (flat command structure)
-  convertedContent = convertedContent.replace(/\/gsd:/g, '/gsd-');
-  // Remap subagent_type="general-purpose" to "general" for OpenCode compatibility
-  convertedContent = convertedContent.replace(/subagent_type="general-purpose"/g, 'subagent_type="general"');
-  // Path replacement is handled by replacePathsInContent() at the call site.
-  // Do NOT do path replacement here to avoid double-replacement.
-
-  // Check if content has frontmatter
-  const { frontmatter: fm, body } = extractFrontmatterAndBody(convertedContent);
-  if (!fm) return convertedContent;
-
-  // Parse frontmatter line by line (simple YAML parsing)
-  const lines = fm.split('\n');
-  const newLines = [];
-  let inAllowedTools = false;
-  let inSkippedArrayField = false;
-  const allowedTools = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    // Skip commented lines when converting agent files (comments not valid in opencode frontmatter)
-    if (isAgent && trimmed.startsWith('#')) {
-      continue;
-    }
-
-    // Strip agent-only fields when isAgent is true (with multi-line array handling)
-    if (isAgent && /^(skills|color|memory|maxTurns|permissionMode|disallowedTools):/.test(trimmed)) {
-      inSkippedArrayField = true;
-      continue;
-    }
-    if (inSkippedArrayField) {
-      if (trimmed.startsWith('- ')) {
-        continue;
-      }
-      inSkippedArrayField = false;
-      // Fall through to process this line normally
-    }
-
-    // Detect start of allowed-tools array
-    if (trimmed.startsWith('allowed-tools:')) {
-      inAllowedTools = true;
-      continue;
-    }
-
-    // Detect inline tools: field (comma-separated string)
-    if (trimmed.startsWith('tools:')) {
-      const toolsValue = trimmed.substring(6).trim();
-      if (toolsValue) {
-        // Parse comma-separated tools
-        const tools = toolsValue.split(',').map(t => t.trim()).filter(t => t);
-        allowedTools.push(...tools);
-      }
-      continue;
-    }
-
-    // Remove name: field - opencode uses filename for command name
-    if (trimmed.startsWith('name:')) {
-      continue;
-    }
-
-    // Convert color names to hex for opencode
-    if (trimmed.startsWith('color:')) {
-      const colorValue = trimmed.substring(6).trim().toLowerCase();
-      const hexColor = colorNameToHex[colorValue];
-      if (hexColor) {
-        newLines.push(`color: "${hexColor}"`);
-      } else if (colorValue.startsWith('#')) {
-        // Validate hex color format (#RGB or #RRGGBB)
-        if (/^#[0-9a-f]{3}$|^#[0-9a-f]{6}$/i.test(colorValue)) {
-          // Already hex and valid, keep as is
-          newLines.push(line);
-        }
-        // Skip invalid hex colors
-      }
-      // Skip unknown color names
-      continue;
-    }
-
-    // Collect allowed-tools items
-    if (inAllowedTools) {
-      if (trimmed.startsWith('- ')) {
-        allowedTools.push(trimmed.substring(2).trim());
-        continue;
-      } else if (trimmed && !trimmed.startsWith('-')) {
-        // End of array, new field started
-        inAllowedTools = false;
-      }
-    }
-
-    // Keep other fields (including name: which opencode ignores)
-    if (!inAllowedTools) {
-      newLines.push(line);
-    }
-  }
-
-  // Add tools object if we had allowed-tools or tools
-  if (allowedTools.length > 0) {
-    newLines.push('tools:');
-    for (const tool of allowedTools) {
-      newLines.push(`  ${convertToolName(tool)}: true`);
-    }
-  }
-
-  // Rebuild frontmatter (body already has tool names converted)
-  const newFrontmatter = newLines.join('\n').trim();
-  return `---\n${newFrontmatter}\n---${body}`;
-}
-
-/**
- * Convert Claude Code markdown command to Gemini TOML format
- * @param {string} content - Markdown file content with YAML frontmatter
- * @returns {string} - TOML content
- */
-function convertClaudeToGeminiToml(content) {
-  const { frontmatter, body: rawBody } = extractFrontmatterAndBody(content);
-  if (!frontmatter) {
-    return `prompt = ${JSON.stringify(content)}\n`;
-  }
-  const body = rawBody.trim();
-  const description = extractFrontmatterField(frontmatter, 'description') || '';
-
-  // Construct TOML
-  let toml = '';
-  if (description) {
-    toml += `description = ${JSON.stringify(description)}\n`;
-  }
-  
-  toml += `prompt = ${JSON.stringify(body)}\n`;
-  
-  return toml;
 }
 
 /**
@@ -1336,7 +958,7 @@ function mergeCodexConfig(configPath, gsdBlock) {
  * lookahead for gsd-knowledge is included as a safety guard.
  *
  * @param {string} content - File content to process
- * @param {string} runtimePathPrefix - Target runtime path (e.g., "~/.config/opencode/")
+ * @param {string} runtimePathPrefix - Target runtime path (e.g., "~/.codex/")
  * @param {string|null} [runtimeLocalPathPrefix] - Relative runtime path for
  * local-scope references (e.g. "./.codex/")
  * @returns {string} Content with paths replaced
@@ -1447,61 +1069,6 @@ function applyVersionScopeToCommands(dir, version, scope) {
 }
 
 /**
- * Copy commands to a flat structure for OpenCode
- * OpenCode expects: command/gsd-help.md (invoked as /gsd-help)
- * Source structure: commands/gsd/help.md
- * 
- * @param {string} srcDir - Source directory (e.g., commands/gsd/)
- * @param {string} destDir - Destination directory (e.g., command/)
- * @param {string} prefix - Prefix for filenames (e.g., 'gsd')
- * @param {string} pathPrefix - Path prefix for file references
- * @param {string} runtime - Target runtime ('claude' or 'opencode')
- */
-function copyFlattenedCommands(srcDir, destDir, prefix, pathPrefix, runtime) {
-  if (!fs.existsSync(srcDir)) {
-    return;
-  }
-  
-  // Remove old gsd-*.md files before copying new ones
-  if (fs.existsSync(destDir)) {
-    for (const file of fs.readdirSync(destDir)) {
-      if (file.startsWith(`${prefix}-`) && file.endsWith('.md')) {
-        fs.unlinkSync(path.join(destDir, file));
-      }
-    }
-  } else {
-    safeFs('mkdirSync', () => fs.mkdirSync(destDir, { recursive: true }), destDir);
-  }
-
-  const entries = fs.readdirSync(srcDir, { withFileTypes: true });
-  
-  for (const entry of entries) {
-    const srcPath = path.join(srcDir, entry.name);
-    
-    if (entry.isDirectory()) {
-      // Recurse into subdirectories, adding to prefix
-      // e.g., commands/gsd/debug/start.md -> command/gsd-debug-start.md
-      copyFlattenedCommands(srcPath, destDir, `${prefix}-${entry.name}`, pathPrefix, runtime);
-    } else if (entry.name.endsWith('.md')) {
-      // Flatten: help.md -> gsd-help.md
-      const baseName = entry.name.replace('.md', '');
-      const destName = `${prefix}-${baseName}.md`;
-      const destPath = path.join(destDir, destName);
-
-      let content = fs.readFileSync(srcPath, 'utf8');
-      content = replacePathsInContent(content, pathPrefix, `./${getDirName(runtime)}/`);
-      // Handle ~/.opencode/ -> target path migration (unrelated to two-pass KB/runtime split)
-      const opencodeDirRegex = /~\/\.opencode\//g;
-      content = content.replace(opencodeDirRegex, pathPrefix);
-      content = processAttribution(content, getCommitAttribution(runtime));
-      content = convertClaudeToOpencodeFrontmatter(content);
-
-      fs.writeFileSync(destPath, content);
-    }
-  }
-}
-
-/**
  * Save user-generated files from destDir to an in-memory map before a wipe.
  * (#1924 upstream fix: preserve USER-PROFILE.md and dev-preferences.md on re-install)
  *
@@ -1544,12 +1111,11 @@ function restoreUserArtifacts(destDir, saved) {
  * @param {string} srcDir - Source directory
  * @param {string} destDir - Destination directory
  * @param {string} pathPrefix - Path prefix for file references
- * @param {string} runtime - Target runtime ('claude', 'opencode', 'gemini', 'codex')
- * @param {boolean} [isCommand=false] - Whether the files being copied are commands (affects Gemini TOML conversion)
+ * @param {string} runtime - Target runtime ('claude' or 'codex')
+ * @param {boolean} [isCommand=false] - Preserved for call-site compatibility
  * @param {boolean} [isGlobal=false] - Whether this is a global install
  */
 function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand = false, isGlobal = false) {
-  const isOpencode = runtime === 'opencode';
   const dirName = getDirName(runtime);
 
   // Clean install: remove existing destination to prevent orphaned files.
@@ -1575,27 +1141,11 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
       content = replacePathsInContent(content, pathPrefix, `./${dirName}/`);
       content = processAttribution(content, getCommitAttribution(runtime));
 
-      // Convert frontmatter for opencode compatibility
-      if (isOpencode) {
-        content = convertClaudeToOpencodeFrontmatter(content);
-        fs.writeFileSync(destPath, content);
-      } else if (runtime === 'gemini') {
-        if (isCommand) {
-          // Only commands get TOML conversion
-          content = stripSubTags(content);
-          const tomlContent = convertClaudeToGeminiToml(content);
-          const tomlPath = destPath.replace(/\.md$/, '.toml');
-          fs.writeFileSync(tomlPath, tomlContent);
-        } else {
-          // Workflow/reference/template files stay as markdown
-          fs.writeFileSync(destPath, content);
-        }
-      } else if (runtime === 'codex') {
+      if (runtime === 'codex') {
         content = convertClaudeToCodexMarkdown(content);
-        fs.writeFileSync(destPath, content);
-      } else {
-        fs.writeFileSync(destPath, content);
       }
+
+      fs.writeFileSync(destPath, content);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
@@ -1844,10 +1394,9 @@ function validateHookFields(settings) {
  * Uninstall GSD from the specified directory for a specific runtime
  * Removes only GSD-specific files/directories, preserves user content
  * @param {boolean} isGlobal - Whether to uninstall from global or local
- * @param {string} runtime - Target runtime ('claude', 'opencode', 'gemini')
+ * @param {string} runtime - Target runtime ('claude' or 'codex')
  */
 function uninstall(isGlobal, runtime = 'claude') {
-  const isOpencode = runtime === 'opencode';
   const isCodex = runtime === 'codex';
   const dirName = getDirName(runtime);
 
@@ -1860,10 +1409,7 @@ function uninstall(isGlobal, runtime = 'claude') {
     ? targetDir.replace(os.homedir(), '~')
     : targetDir.replace(process.cwd(), '.');
 
-  let runtimeLabel = 'Claude Code';
-  if (runtime === 'opencode') runtimeLabel = 'OpenCode';
-  if (runtime === 'gemini') runtimeLabel = 'Gemini';
-  if (runtime === 'codex') runtimeLabel = 'Codex CLI';
+  const runtimeLabel = getInstallerRuntimeLabel(runtime);
 
   console.log(`  Uninstalling GSDR from ${cyan}${runtimeLabel}${reset} at ${cyan}${locationLabel}${reset}\n`);
 
@@ -1896,23 +1442,8 @@ function uninstall(isGlobal, runtime = 'claude') {
         console.log(`  ${green}✓${reset} Removed GSDR skills`);
       }
     }
-  } else if (isOpencode) {
-    const commandDir = path.join(targetDir, 'command');
-    if (fs.existsSync(commandDir)) {
-      const files = fs.readdirSync(commandDir);
-      for (const file of files) {
-        if (file.startsWith('gsdr-') && file.endsWith('.md')) {
-          fs.unlinkSync(path.join(commandDir, file));
-          removedCount++;
-        } else if (cleanLegacy && file.startsWith('gsd-') && file.endsWith('.md')) {
-          fs.unlinkSync(path.join(commandDir, file));
-          removedCount++;
-        }
-      }
-      console.log(`  ${green}✓${reset} Removed GSDR commands from command/`);
-    }
   } else {
-    // Claude Code & Gemini: remove commands/gsdr/ (and commands/gsd/ only if legacy Reflect)
+    // Claude Code: remove commands/gsdr/ (and commands/gsd/ only if legacy Reflect)
     const gsdrCommandsDir = path.join(targetDir, 'commands', 'gsdr');
     if (fs.existsSync(gsdrCommandsDir)) {
       fs.rmSync(gsdrCommandsDir, { recursive: true });
@@ -2126,48 +1657,6 @@ function uninstall(isGlobal, runtime = 'claude') {
     }
   }
 
-  // 6. For OpenCode, clean up permissions from opencode config
-  if (isOpencode) {
-    const opencodeConfigDir = getOpencodeGlobalDir();
-    const configPath = resolveOpencodeConfigPath(opencodeConfigDir);
-    if (fs.existsSync(configPath)) {
-      try {
-        const config = readSettings(configPath);
-        let modified = false;
-
-        // Remove GSD permission entries
-        if (config.permission) {
-          for (const permType of ['read', 'external_directory']) {
-            if (config.permission[permType]) {
-              const keys = Object.keys(config.permission[permType]);
-              for (const key of keys) {
-                if (key.includes('get-shit-done')) {
-                  delete config.permission[permType][key];
-                  modified = true;
-                }
-              }
-              // Clean up empty objects
-              if (Object.keys(config.permission[permType]).length === 0) {
-                delete config.permission[permType];
-              }
-            }
-          }
-          if (Object.keys(config.permission).length === 0) {
-            delete config.permission;
-          }
-        }
-
-        if (modified) {
-          fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-          removedCount++;
-          console.log(`  ${green}✓${reset} Removed GSD permissions from opencode.json`);
-        }
-      } catch (e) {
-        // Ignore JSON parse errors
-      }
-    }
-  }
-
   // Remove the file manifest that the installer wrote at install time.
   // Without this step the metadata file persists after uninstall (#1908).
   const manifestPath = path.join(targetDir, MANIFEST_NAME);
@@ -2192,130 +1681,6 @@ function uninstall(isGlobal, runtime = 'claude') {
  * OpenCode supports JSONC format via jsonc-parser, so users may have comments.
  * This is a lightweight inline parser to avoid adding dependencies.
  */
-function parseJsonc(content) {
-  // Strip BOM if present
-  if (content.charCodeAt(0) === 0xFEFF) {
-    content = content.slice(1);
-  }
-
-  // Remove single-line and block comments while preserving strings
-  let result = '';
-  let inString = false;
-  let i = 0;
-  while (i < content.length) {
-    const char = content[i];
-    const next = content[i + 1];
-
-    if (inString) {
-      result += char;
-      // Handle escape sequences
-      if (char === '\\' && i + 1 < content.length) {
-        result += next;
-        i += 2;
-        continue;
-      }
-      if (char === '"') {
-        inString = false;
-      }
-      i++;
-    } else {
-      if (char === '"') {
-        inString = true;
-        result += char;
-        i++;
-      } else if (char === '/' && next === '/') {
-        // Skip single-line comment until end of line
-        while (i < content.length && content[i] !== '\n') {
-          i++;
-        }
-      } else if (char === '/' && next === '*') {
-        // Skip block comment
-        i += 2;
-        while (i < content.length - 1 && !(content[i] === '*' && content[i + 1] === '/')) {
-          i++;
-        }
-        i += 2; // Skip closing */
-      } else {
-        result += char;
-        i++;
-      }
-    }
-  }
-
-  // Remove trailing commas before } or ]
-  result = result.replace(/,(\s*[}\]])/g, '$1');
-
-  return JSON.parse(result);
-}
-
-/**
- * Configure OpenCode permissions to allow reading GSD reference docs
- * This prevents permission prompts when GSD accesses the get-shit-done directory
- */
-function configureOpencodePermissions() {
-  // OpenCode config file - prefers .jsonc when it exists, falls back to .json
-  const opencodeConfigDir = getOpencodeGlobalDir();
-  const configPath = resolveOpencodeConfigPath(opencodeConfigDir);
-
-  // Ensure config directory exists
-  safeFs('mkdirSync', () => fs.mkdirSync(opencodeConfigDir, { recursive: true }), opencodeConfigDir);
-
-  // Read existing config or create empty object
-  let config = {};
-  if (fs.existsSync(configPath)) {
-    try {
-      const content = fs.readFileSync(configPath, 'utf8');
-      config = parseJsonc(content);
-    } catch (e) {
-      // Cannot parse - DO NOT overwrite user's config
-      console.log(`  ${yellow}⚠${reset} Could not parse opencode.json - skipping permission config`);
-      console.log(`    ${dim}Reason: ${e.message}${reset}`);
-      console.log(`    ${dim}Your config was NOT modified. Fix the syntax manually if needed.${reset}`);
-      return;
-    }
-  }
-
-  // Ensure permission structure exists
-  if (!config.permission) {
-    config.permission = {};
-  }
-
-  // Build the GSD path using the actual config directory
-  // Use ~ shorthand if it's in the default location, otherwise use full path
-  const defaultConfigDir = path.join(os.homedir(), '.config', 'opencode');
-  const gsdPath = opencodeConfigDir === defaultConfigDir
-    ? '~/.config/opencode/get-shit-done-reflect/*'
-    : `${opencodeConfigDir.replace(/\\/g, '/')}/get-shit-done-reflect/*`;
-  
-  let modified = false;
-
-  // Configure read permission
-  if (!config.permission.read || typeof config.permission.read !== 'object') {
-    config.permission.read = {};
-  }
-  if (config.permission.read[gsdPath] !== 'allow') {
-    config.permission.read[gsdPath] = 'allow';
-    modified = true;
-  }
-
-  // Configure external_directory permission (the safety guard for paths outside project)
-  if (!config.permission.external_directory || typeof config.permission.external_directory !== 'object') {
-    config.permission.external_directory = {};
-  }
-  if (config.permission.external_directory[gsdPath] !== 'allow') {
-    config.permission.external_directory[gsdPath] = 'allow';
-    modified = true;
-  }
-
-  if (!modified) {
-    return; // Already configured
-  }
-
-  // Write config back
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n');
-  console.log(`  ${green}✓${reset} Configured read permission for GSD docs`);
-}
-
 /**
  * Verify a directory exists and contains files
  */
@@ -2351,7 +1716,7 @@ function verifyFileInstalled(filePath, description) {
 /**
  * Install to the specified directory for a specific runtime
  * @param {boolean} isGlobal - Whether to install globally or locally
- * @param {string} runtime - Target runtime ('claude', 'opencode', 'gemini')
+ * @param {string} runtime - Target runtime ('claude' or 'codex')
  */
 
 // ──────────────────────────────────────────────────────
@@ -2568,8 +1933,6 @@ function reportLocalPatches(configDir) {
 }
 
 function install(isGlobal, runtime = 'claude') {
-  const isOpencode = runtime === 'opencode';
-  const isGemini = runtime === 'gemini';
   const isCodex = runtime === 'codex';
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
@@ -2590,10 +1953,7 @@ function install(isGlobal, runtime = 'claude') {
     ? `$HOME/${path.basename(targetDir)}/`
     : `./${dirName}/`;
 
-  let runtimeLabel = 'Claude Code';
-  if (isOpencode) runtimeLabel = 'OpenCode';
-  if (isGemini) runtimeLabel = 'Gemini';
-  if (isCodex) runtimeLabel = 'Codex CLI';
+  const runtimeLabel = getInstallerRuntimeLabel(runtime);
 
   // Cache legacy detection once — reads and parses gsd-file-manifest.json
   const cleanLegacy = isLegacyReflectInstall(targetDir);
@@ -2643,9 +2003,7 @@ function install(isGlobal, runtime = 'claude') {
   // Clean up orphaned files from previous versions
   cleanupOrphanedFiles(targetDir);
 
-  // Codex: Skills in skills/ directory
-  // OpenCode uses 'command/' (singular) with flat structure
-  // Claude Code & Gemini use 'commands/' (plural) with nested structure
+  // Codex uses skills/; Claude uses commands/.
   if (isCodex) {
     const skillsDir = path.join(targetDir, 'skills');
     safeFs('mkdirSync', () => fs.mkdirSync(skillsDir, { recursive: true }), skillsDir);
@@ -2661,24 +2019,8 @@ function install(isGlobal, runtime = 'claude') {
     }
     // Inject version/scope into Codex skill descriptions
     applyVersionScopeToCommands(skillsDir, versionString, isGlobal ? 'global' : 'local');
-  } else if (isOpencode) {
-    // OpenCode: flat structure in command/ directory
-    const commandDir = path.join(targetDir, 'command');
-    safeFs('mkdirSync', () => fs.mkdirSync(commandDir, { recursive: true }), commandDir);
-
-    // Copy commands/gsd/*.md as command/gsdr-*.md (flatten structure)
-    const gsdSrc = path.join(src, 'commands', 'gsd');
-    copyFlattenedCommands(gsdSrc, commandDir, 'gsdr', pathPrefix, runtime);
-    if (verifyInstalled(commandDir, 'command/gsdr-*')) {
-      const count = fs.readdirSync(commandDir).filter(f => f.startsWith('gsdr-')).length;
-      console.log(`  ${green}✓${reset} Installed ${count} commands to command/`);
-    } else {
-      failures.push('command/gsdr-*');
-    }
-    // Inject version/scope into OpenCode command descriptions
-    applyVersionScopeToCommands(commandDir, versionString, isGlobal ? 'global' : 'local');
   } else {
-    // Claude Code & Gemini: nested structure in commands/ directory
+    // Claude Code: nested structure in commands/ directory
     const commandsDir = path.join(targetDir, 'commands');
     safeFs('mkdirSync', () => fs.mkdirSync(commandsDir, { recursive: true }), commandsDir);
 
@@ -2690,7 +2032,7 @@ function install(isGlobal, runtime = 'claude') {
     } else {
       failures.push('commands/gsdr');
     }
-    // Inject version/scope into Claude/Gemini command descriptions
+    // Inject version/scope into Claude command descriptions
     applyVersionScopeToCommands(gsdDest, versionString, isGlobal ? 'global' : 'local');
   }
 
@@ -2712,7 +2054,7 @@ function install(isGlobal, runtime = 'claude') {
     console.log(`  ${yellow}!${reset} Feature manifest not found (expected at ${manifestDest})`);
   }
 
-  // Copy agents to agents directory (Claude/OpenCode/Gemini: .md files; Codex: .toml files)
+  // Copy agents to agents directory (Claude: .md files; Codex: .toml files)
   const agentsSrc = path.join(src, 'agents');
   if (fs.existsSync(agentsSrc) && !isCodex) {
     const agentsDest = path.join(targetDir, 'agents');
@@ -2737,12 +2079,6 @@ function install(isGlobal, runtime = 'claude') {
         // Replace paths using centralized two-pass function
         content = replacePathsInContent(content, pathPrefix, `./${getDirName(runtime)}/`);
         content = processAttribution(content, getCommitAttribution(runtime));
-        // Convert frontmatter for runtime compatibility
-        if (isOpencode) {
-          content = convertClaudeToOpencodeFrontmatter(content, { isAgent: true });
-        } else if (isGemini) {
-          content = convertClaudeToGeminiAgent(content);
-        }
         // Rename gsd-*.md -> gsdr-*.md (preserves knowledge-store.md, kb-templates/)
         const destName = entry.name.startsWith('gsd-')
           ? entry.name.replace(/^gsd-/, 'gsdr-')
@@ -2901,6 +2237,18 @@ function install(isGlobal, runtime = 'claude') {
 
   // Codex: no settings.json, hooks, or statusline -- write manifest and return
   if (isCodex) {
+    const gsdHome = getGsdHome();
+    const defaultsPath = path.join(gsdHome, 'defaults.json');
+    let defaults = {};
+    if (fs.existsSync(defaultsPath)) {
+      try { defaults = JSON.parse(fs.readFileSync(defaultsPath, 'utf8')); } catch {}
+    }
+    if (defaults.resolve_model_ids !== 'omit') {
+      defaults.resolve_model_ids = 'omit';
+      fs.writeFileSync(defaultsPath, JSON.stringify(defaults, null, 2) + '\n');
+      console.log(`  ${green}+${reset} Set resolve_model_ids: omit for ${runtimeLabel}`);
+    }
+
     writeManifest(targetDir);
     console.log(`  ${green}✓${reset} Wrote file manifest (${MANIFEST_NAME})`);
     pruneRedundantPatches(targetDir);
@@ -2909,7 +2257,6 @@ function install(isGlobal, runtime = 'claude') {
   }
 
   // Configure statusline and hooks in settings.json
-  // Gemini shares same hook system as Claude Code for now
   const settingsPath = path.join(targetDir, 'settings.json');
   const settings = validateHookFields(cleanupOrphanedHooks(readSettings(settingsPath)));
   const statuslineCommand = isGlobal
@@ -2930,125 +2277,89 @@ function install(isGlobal, runtime = 'claude') {
   const contextMonitorCommand = isGlobal
     ? buildHookCommand(targetDir, 'gsdr-context-monitor.js')
     : 'node ' + dirName + '/hooks/gsdr-context-monitor.js';
-
-  // Enable experimental agents for Gemini CLI (required for custom sub-agents)
-  if (isGemini) {
-    if (!settings.experimental) {
-      settings.experimental = {};
-    }
-    if (!settings.experimental.enableAgents) {
-      settings.experimental.enableAgents = true;
-      console.log(`  ${green}✓${reset} Enabled experimental agents`);
-    }
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+  if (!settings.hooks.SessionStart) {
+    settings.hooks.SessionStart = [];
   }
 
-  // Configure SessionStart hook for update checking (skip for opencode)
-  if (!isOpencode) {
-    if (!settings.hooks) {
-      settings.hooks = {};
-    }
-    if (!settings.hooks.SessionStart) {
-      settings.hooks.SessionStart = [];
-    }
-
-    // Helper: add hook if missing, or upgrade unguarded command to guarded version.
-    // Guard: only register if the hook file was actually installed (#1754 upstream).
-    // When hooks/dist/ is missing from the npm package, the copy step produces no
-    // files but the registration step ran unconditionally, causing hook errors on
-    // every tool invocation.
-    function ensureHook(hookSubstring, newCommand, label, hookFileName) {
-      const hookFile = path.join(targetDir, 'hooks', hookFileName);
-      const existingEntry = settings.hooks.SessionStart.find(entry =>
-        entry.hooks && entry.hooks.some(h => h.command && h.command.includes(hookSubstring))
-      );
-
-      if (!existingEntry) {
-        if (fs.existsSync(hookFile)) {
-          // Hook not present -- add it
-          settings.hooks.SessionStart.push({
-            hooks: [{ type: 'command', command: newCommand }]
-          });
-          console.log(`  ${green}✓${reset} Configured ${label} hook`);
-        } else {
-          console.warn(`  ${yellow}⚠${reset}  Skipped ${label} hook — ${hookFileName} not found at target`);
-        }
-      } else if (!isGlobal) {
-        // Hook exists -- upgrade to guarded command if not already guarded
-        const hook = existingEntry.hooks.find(h => h.command && h.command.includes(hookSubstring));
-        if (hook && !hook.command.includes('test -f')) {
-          hook.command = newCommand;
-          console.log(`  ${green}✓${reset} Upgraded ${label} hook (worktree-safe guard)`);
-        }
-      }
-    }
-
-    ensureHook('gsdr-check-update', updateCheckCommand, 'update check', 'gsdr-check-update.js');
-    ensureHook('gsdr-version-check', versionCheckCommand, 'version check', 'gsdr-version-check.js');
-    ensureHook('gsdr-ci-status', ciStatusCommand, 'CI status', 'gsdr-ci-status.js');
-    ensureHook('gsdr-health-check', healthCheckCommand, 'health check', 'gsdr-health-check.js');
-
-    // Configure post-tool hook for context window monitoring
-    // Uses direct push (not ensureHook) because this is PostToolUse, not SessionStart
-    const postToolEvent = (runtime === 'gemini' || runtime === 'antigravity') ? 'AfterTool' : 'PostToolUse';
-    if (!settings.hooks[postToolEvent]) {
-      settings.hooks[postToolEvent] = [];
-    }
-
-    const hasContextMonitorHook = settings.hooks[postToolEvent].some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsdr-context-monitor'))
+  // Helper: add hook if missing, or upgrade unguarded command to guarded version.
+  // Guard: only register if the hook file was actually installed (#1754 upstream).
+  // When hooks/dist/ is missing from the npm package, the copy step produces no
+  // files but the registration step ran unconditionally, causing hook errors on
+  // every tool invocation.
+  function ensureHook(hookSubstring, newCommand, label, hookFileName) {
+    const hookFile = path.join(targetDir, 'hooks', hookFileName);
+    const existingEntry = settings.hooks.SessionStart.find(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes(hookSubstring))
     );
 
-    const contextMonitorFile = path.join(targetDir, 'hooks', 'gsdr-context-monitor.js');
-    if (!hasContextMonitorHook && fs.existsSync(contextMonitorFile)) {
-      settings.hooks[postToolEvent].push({
-        matcher: 'Bash|Edit|Write|MultiEdit|Agent|Task',
-        hooks: [
-          {
-            type: 'command',
-            command: contextMonitorCommand,
-            timeout: 10
-          }
-        ]
-      });
-      console.log(`  ${green}✓${reset} Configured context window monitor hook`);
-    } else if (!hasContextMonitorHook && !fs.existsSync(contextMonitorFile)) {
-      console.warn(`  ${yellow}⚠${reset}  Skipped context monitor hook — gsdr-context-monitor.js not found at target`);
-    } else {
-      // Migrate existing context monitor hooks: add matcher and timeout if missing
-      for (const entry of settings.hooks[postToolEvent]) {
-        if (entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsdr-context-monitor'))) {
-          let migrated = false;
-          if (!entry.matcher) {
-            entry.matcher = 'Bash|Edit|Write|MultiEdit|Agent|Task';
-            migrated = true;
-          }
-          for (const h of entry.hooks) {
-            if (h.command && h.command.includes('gsdr-context-monitor') && !h.timeout) {
-              h.timeout = 10;
-              migrated = true;
-            }
-          }
-          if (migrated) {
-            console.log(`  ${green}✓${reset} Updated context monitor hook (added matcher + timeout)`);
-          }
-        }
+    if (!existingEntry) {
+      if (fs.existsSync(hookFile)) {
+        settings.hooks.SessionStart.push({
+          hooks: [{ type: 'command', command: newCommand }]
+        });
+        console.log(`  ${green}✓${reset} Configured ${label} hook`);
+      } else {
+        console.warn(`  ${yellow}⚠${reset}  Skipped ${label} hook — ${hookFileName} not found at target`);
+      }
+    } else if (!isGlobal) {
+      const hook = existingEntry.hooks.find(h => h.command && h.command.includes(hookSubstring));
+      if (hook && !hook.command.includes('test -f')) {
+        hook.command = newCommand;
+        console.log(`  ${green}✓${reset} Upgraded ${label} hook (worktree-safe guard)`);
       }
     }
   }
 
-  // C6: Set resolve_model_ids for non-Claude runtimes
-  const isClaude = !isOpencode && !isGemini && !isCodex;
-  if (!isClaude) {
-    const gsdHome = getGsdHome();
-    const defaultsPath = path.join(gsdHome, 'defaults.json');
-    let defaults = {};
-    if (fs.existsSync(defaultsPath)) {
-      try { defaults = JSON.parse(fs.readFileSync(defaultsPath, 'utf8')); } catch {}
-    }
-    if (defaults.resolve_model_ids !== 'omit') {
-      defaults.resolve_model_ids = 'omit';
-      fs.writeFileSync(defaultsPath, JSON.stringify(defaults, null, 2) + '\n');
-      console.log(`  ${green}+${reset} Set resolve_model_ids: omit for ${runtimeLabel}`);
+  ensureHook('gsdr-check-update', updateCheckCommand, 'update check', 'gsdr-check-update.js');
+  ensureHook('gsdr-version-check', versionCheckCommand, 'version check', 'gsdr-version-check.js');
+  ensureHook('gsdr-ci-status', ciStatusCommand, 'CI status', 'gsdr-ci-status.js');
+  ensureHook('gsdr-health-check', healthCheckCommand, 'health check', 'gsdr-health-check.js');
+
+  // Configure post-tool hook for context window monitoring
+  if (!settings.hooks.PostToolUse) {
+    settings.hooks.PostToolUse = [];
+  }
+
+  const hasContextMonitorHook = settings.hooks.PostToolUse.some(entry =>
+    entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsdr-context-monitor'))
+  );
+
+  const contextMonitorFile = path.join(targetDir, 'hooks', 'gsdr-context-monitor.js');
+  if (!hasContextMonitorHook && fs.existsSync(contextMonitorFile)) {
+    settings.hooks.PostToolUse.push({
+      matcher: 'Bash|Edit|Write|MultiEdit|Agent|Task',
+      hooks: [
+        {
+          type: 'command',
+          command: contextMonitorCommand,
+          timeout: 10
+        }
+      ]
+    });
+    console.log(`  ${green}✓${reset} Configured context window monitor hook`);
+  } else if (!hasContextMonitorHook && !fs.existsSync(contextMonitorFile)) {
+    console.warn(`  ${yellow}⚠${reset}  Skipped context monitor hook — gsdr-context-monitor.js not found at target`);
+  } else {
+    for (const entry of settings.hooks.PostToolUse) {
+      if (entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsdr-context-monitor'))) {
+        let migrated = false;
+        if (!entry.matcher) {
+          entry.matcher = 'Bash|Edit|Write|MultiEdit|Agent|Task';
+          migrated = true;
+        }
+        for (const h of entry.hooks) {
+          if (h.command && h.command.includes('gsdr-context-monitor') && !h.timeout) {
+            h.timeout = 10;
+            migrated = true;
+          }
+        }
+        if (migrated) {
+          console.log(`  ${green}✓${reset} Updated context monitor hook (added matcher + timeout)`);
+        }
+      }
     }
   }
 
@@ -3069,15 +2380,13 @@ function install(isGlobal, runtime = 'claude') {
  * Apply statusline config, then print completion message
  */
 function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallStatusline, runtime = 'claude') {
-  const isOpencode = runtime === 'opencode';
-
-  if (shouldInstallStatusline && !isOpencode) {
+  if (shouldInstallStatusline) {
     settings.statusLine = {
       type: 'command',
       command: statuslineCommand
     };
     console.log(`  ${green}✓${reset} Configured statusline`);
-  } else if (!isOpencode && settings.statusLine && settings.statusLine.command &&
+  } else if (settings.statusLine && settings.statusLine.command &&
              settings.statusLine.command.includes('statusline') &&
              !settings.statusLine.command.includes('test -f') &&
              statuslineCommand && statuslineCommand.includes('test -f')) {
@@ -3091,18 +2400,9 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   // Always write settings
   writeSettings(settingsPath, settings);
 
-  // Configure OpenCode permissions
-  if (isOpencode) {
-    configureOpencodePermissions();
-  }
-
-  let program = 'Claude Code';
-  if (runtime === 'opencode') program = 'OpenCode';
-  if (runtime === 'gemini') program = 'Gemini';
-
-  const command = isOpencode ? '/gsdr-help' : '/gsdr:help';
+  const program = getInstallerRuntimeLabel(runtime);
   console.log(`
-  ${green}Done!${reset} Launch ${program} and run ${cyan}${command}${reset}.
+  ${green}Done!${reset} Launch ${program} and run ${cyan}/gsdr:help${reset}.
 
   ${cyan}Join the community:${reset} https://github.com/loganrooks/get-shit-done-reflect/discussions
 `);
@@ -3178,25 +2478,19 @@ function promptRuntime(callback) {
     }
   });
 
-  console.log(`  ${yellow}Which runtime(s) would you like to install for?${reset}\n\n  ${cyan}1${reset}) Claude Code ${dim}(~/.claude)${reset}
-  ${cyan}2${reset}) OpenCode    ${dim}(~/.config/opencode)${reset} - open source, free models
-  ${cyan}3${reset}) Gemini      ${dim}(~/.gemini)${reset}
-  ${cyan}4${reset}) Codex CLI   ${dim}(~/.codex)${reset}
-  ${cyan}5${reset}) All
+  console.log(`  ${yellow}Which runtime(s) would you like to install for?${reset}\n\n  ${cyan}1${reset}) ${INSTALLER_RUNTIME_METADATA.claude.label} ${dim}(${INSTALLER_RUNTIME_METADATA.claude.globalDirDisplay})${reset}
+  ${cyan}2${reset}) ${INSTALLER_RUNTIME_METADATA.codex.label}  ${dim}(${INSTALLER_RUNTIME_METADATA.codex.globalDirDisplay})${reset}
+  ${cyan}3${reset}) All supported runtimes
 `);
 
   rl.question(`  Choice ${dim}[1]${reset}: `, (answer) => {
     answered = true;
     rl.close();
     const choice = answer.trim() || '1';
-    if (choice === '5') {
-      callback(['claude', 'opencode', 'gemini', 'codex']);
-    } else if (choice === '4') {
-      callback(['codex']);
-    } else if (choice === '3') {
-      callback(['gemini']);
+    if (choice === '3') {
+      callback([...SUPPORTED_INSTALLER_RUNTIMES]);
     } else if (choice === '2') {
-      callback(['opencode']);
+      callback(['codex']);
     } else {
       callback(['claude']);
     }
@@ -3267,28 +2561,11 @@ function installAllRuntimes(runtimes, isGlobal, isInteractive) {
     results.push(result);
   }
 
-  // Handle statusline for Claude & Gemini (OpenCode uses themes)
   const claudeResult = results.find(r => r.runtime === 'claude');
-  const geminiResult = results.find(r => r.runtime === 'gemini');
-
-  // Logic: if both are present, ask once if interactive? Or ask for each?
-  // Simpler: Ask once and apply to both if applicable.
-  
-  if (claudeResult || geminiResult) {
-    // Use whichever settings exist to check for existing statusline
-    const primaryResult = claudeResult || geminiResult;
-
-    handleStatusline(primaryResult.settings, isInteractive, (shouldInstallStatusline) => {
+  if (claudeResult) {
+    handleStatusline(claudeResult.settings, isInteractive, (shouldInstallStatusline) => {
       if (claudeResult) {
         finishInstall(claudeResult.settingsPath, claudeResult.settings, claudeResult.statuslineCommand, shouldInstallStatusline, 'claude');
-      }
-      if (geminiResult) {
-         finishInstall(geminiResult.settingsPath, geminiResult.settings, geminiResult.statuslineCommand, shouldInstallStatusline, 'gemini');
-      }
-
-      const opencodeResult = results.find(r => r.runtime === 'opencode');
-      if (opencodeResult) {
-        finishInstall(opencodeResult.settingsPath, opencodeResult.settings, opencodeResult.statuslineCommand, false, 'opencode');
       }
 
       const codexResult = results.find(r => r.runtime === 'codex');
@@ -3297,12 +2574,6 @@ function installAllRuntimes(runtimes, isGlobal, isInteractive) {
       }
     });
   } else {
-    // Only non-Claude/non-Gemini runtimes
-    const opencodeResult = results.find(r => r.runtime === 'opencode');
-    if (opencodeResult) {
-      finishInstall(opencodeResult.settingsPath, opencodeResult.settings, opencodeResult.statuslineCommand, false, 'opencode');
-    }
-
     const codexResult = results.find(r => r.runtime === 'codex');
     if (codexResult) {
       console.log(`\n  ${green}Done!${reset} Launch Codex CLI and run ${cyan}$gsdr-help${reset}.\n`);
@@ -3314,6 +2585,9 @@ function installAllRuntimes(runtimes, isGlobal, isInteractive) {
 if (require.main === module) {
 if (hasGlobal && hasLocal) {
   console.error(`  ${yellow}Cannot specify both --global and --local${reset}`);
+  process.exit(1);
+} else if (runtimeSelectionError) {
+  console.error(`  ${yellow}${runtimeSelectionError.message}${reset}`);
   process.exit(1);
 } else if (explicitConfigDir && hasLocal) {
   console.error(`  ${yellow}Cannot use --config-dir with --local${reset}`);
@@ -3351,4 +2625,4 @@ if (hasGlobal && hasLocal) {
 } // end require.main === module
 
 // Export for testing
-module.exports = { replacePathsInContent, injectVersionScope, getGsdHome, migrateKB, countKBEntries, installKBScripts, createProjectLocalKB, convertClaudeToCodexSkill, convertClaudeToCodexMarkdown, convertClaudeToCodexAgentToml, copyCodexSkills, generateCodexAgentsMd, generateCodexMcpConfig, generateCodexConfigBlock, stripGsdFromCodexConfig, mergeCodexConfig, CODEX_AGENT_SANDBOX, GSD_CODEX_MARKER, convertClaudeToGeminiAgent, safeFs, buildLocalHookCommand, extractFrontmatterAndBody, extractFrontmatterField, convertClaudeToOpencodeFrontmatter, resolveOpencodeConfigPath, readSettings, writeSettings, copyWithPathReplacement, generateMigrationGuide, isVersionInRange, compareVersions, cleanupOrphanedFiles, validateHookFields, getCodexCompactPromptPath };
+module.exports = { replacePathsInContent, injectVersionScope, getGsdHome, migrateKB, countKBEntries, installKBScripts, createProjectLocalKB, convertClaudeToCodexSkill, convertClaudeToCodexMarkdown, convertClaudeToCodexAgentToml, copyCodexSkills, generateCodexAgentsMd, generateCodexMcpConfig, generateCodexConfigBlock, stripGsdFromCodexConfig, mergeCodexConfig, CODEX_AGENT_SANDBOX, GSD_CODEX_MARKER, safeFs, buildLocalHookCommand, extractFrontmatterAndBody, extractFrontmatterField, readSettings, writeSettings, copyWithPathReplacement, generateMigrationGuide, isVersionInRange, compareVersions, cleanupOrphanedFiles, validateHookFields, getCodexCompactPromptPath };

--- a/bin/install.js
+++ b/bin/install.js
@@ -512,7 +512,6 @@ function processAttribution(content, attribution) {
   return content.replace(/Co-Authored-By:.*$/gim, `Co-Authored-By: ${safeAttribution}`);
 }
 
-/**
 // Tool name mapping from Claude Code to Codex CLI
 // Codex CLI uses snake_case built-in tool names (codex-rs)
 const claudeToCodexTools = {

--- a/get-shit-done/bin/lib/runtime-support.cjs
+++ b/get-shit-done/bin/lib/runtime-support.cjs
@@ -1,0 +1,67 @@
+'use strict';
+
+const INSTALLER_RUNTIME_METADATA = Object.freeze({
+  claude: Object.freeze({
+    flag: '--claude',
+    label: 'Claude Code',
+    dirName: '.claude',
+    globalDirDisplay: '~/.claude',
+  }),
+  codex: Object.freeze({
+    flag: '--codex',
+    label: 'Codex CLI',
+    dirName: '.codex',
+    globalDirDisplay: '~/.codex',
+  }),
+});
+
+const SUPPORTED_INSTALLER_RUNTIMES = Object.freeze(Object.keys(INSTALLER_RUNTIME_METADATA));
+const UNSUPPORTED_INSTALLER_TARGETS = Object.freeze(['opencode', 'gemini', 'both']);
+
+function getInstallerRuntimeMetadata(runtime) {
+  return INSTALLER_RUNTIME_METADATA[runtime] || null;
+}
+
+function getInstallerRuntimeLabel(runtime) {
+  return getInstallerRuntimeMetadata(runtime)?.label || runtime;
+}
+
+function expandInstallerRuntimeSelection({ all = false, explicit = [] } = {}) {
+  if (all) {
+    return [...SUPPORTED_INSTALLER_RUNTIMES];
+  }
+
+  const unique = [];
+  for (const runtime of explicit) {
+    if (SUPPORTED_INSTALLER_RUNTIMES.includes(runtime) && !unique.includes(runtime)) {
+      unique.push(runtime);
+    }
+  }
+
+  return unique;
+}
+
+function formatUnsupportedRuntimeMessage(targets) {
+  const requested = [...new Set(targets)].map((target) => (target === 'both' ? '--both' : `--${target}`));
+  const supportedFlags = SUPPORTED_INSTALLER_RUNTIMES
+    .map((runtime) => getInstallerRuntimeMetadata(runtime).flag)
+    .join(', ');
+  const plural = requested.length === 1 ? '' : 's';
+
+  return [
+    `Unsupported installer target${plural}: ${requested.join(', ')}.`,
+    `Supported installer targets: ${supportedFlags}, or --all for all supported runtimes.`,
+    'Legacy Gemini/OpenCode installer support has been removed and is not silently remapped.',
+    'If you previously installed those runtimes, remove stale GSDR files from .gemini/, .opencode/, or ~/.config/opencode/ manually if needed.',
+  ].join('\n');
+}
+
+module.exports = {
+  INSTALLER_RUNTIME_METADATA,
+  SUPPORTED_INSTALLER_RUNTIMES,
+  UNSUPPORTED_INSTALLER_TARGETS,
+  getInstallerRuntimeMetadata,
+  getInstallerRuntimeLabel,
+  expandInstallerRuntimeSelection,
+  formatUnsupportedRuntimeMessage,
+};

--- a/get-shit-done/references/capability-matrix.md
+++ b/get-shit-done/references/capability-matrix.md
@@ -12,14 +12,15 @@
 # Runtime Capability Matrix
 
 > Reference document for GSD workflow orchestrators. Declares which features
-> are available in each supported runtime. Workflows use `has_capability()`
-> patterns to branch behavior based on this matrix.
+> are available across the runtime columns tracked here. Workflows use
+> `has_capability()` patterns to branch behavior based on this matrix.
 
 > **Deprecation Notice (v1.20):** Gemini CLI and OpenCode columns are retained for
 > reference but are **community-maintained and not tested by the GSD Reflect team**.
 > The two supported runtimes are **Claude Code** and **Codex CLI**. The `--gemini`
-> and `--opencode` installer flags still work but produce unsupported configurations.
-> New workflows use binary Claude/Codex branching only -- no new `<capability_check>`
+> and `--opencode` installer flags, along with the legacy installer `--both` flag,
+> now fail with migration guidance instead of installing unsupported runtimes. New
+> workflows use binary Claude/Codex branching only -- no new `<capability_check>`
 > blocks will be added for Gemini CLI or OpenCode.
 
 ## Quick Reference
@@ -100,7 +101,7 @@ No orchestrator adaptation needed. The installer preserves tool permission front
 MCP (Model Context Protocol) server integration. Allows agents to access external tools and services via the MCP protocol.
 
 **Available in:** Claude Code, OpenCode, Gemini CLI, Codex CLI
-**Status:** Available in all supported runtimes.
+**Status:** Available in both supported runtimes and the deprecated reference runtimes listed here.
 
 **Transport support by runtime:**
 - Claude Code: STDIO, SSE, Streamable HTTP
@@ -109,7 +110,7 @@ MCP (Model Context Protocol) server integration. Allows agents to access externa
 - Codex CLI: STDIO, Streamable HTTP. OAuth support.
 
 **Degraded behavior (informational):**
-All four supported runtimes now support MCP servers. This section is retained for documentation purposes -- if a future runtime lacks MCP support, the degraded behavior is: MCP-dependent features are skipped, MCP tool references in agent specs are excluded during format conversion, and agents function with their built-in tools only.
+Both supported runtimes, plus the deprecated Gemini/OpenCode reference columns, currently support MCP servers. This section is retained for documentation purposes -- if a future runtime lacks MCP support, the degraded behavior is: MCP-dependent features are skipped, MCP tool references in agent specs are excluded during format conversion, and agents function with their built-in tools only.
 
 **How orchestrators adapt:**
 No orchestrator adaptation needed. The installer preserves MCP tool references for all runtimes. MCP server configuration is handled at the runtime config level (settings.json, opencode.json, config.toml).

--- a/tests/integration/cross-runtime-kb.test.js
+++ b/tests/integration/cross-runtime-kb.test.js
@@ -12,6 +12,37 @@ const GSD_TOOLS = path.resolve(REPO_ROOT, 'get-shit-done/bin/gsd-tools.cjs')
 const require = createRequire(import.meta.url)
 const { DatabaseSync } = require('node:sqlite')
 const { reconstructFrontmatter } = require('../../get-shit-done/bin/lib/frontmatter.cjs')
+const {
+  INSTALLER_RUNTIME_METADATA,
+  SUPPORTED_INSTALLER_RUNTIMES,
+} = require('../../get-shit-done/bin/lib/runtime-support.cjs')
+
+async function pathExists(targetPath) {
+  return fs.access(targetPath).then(() => true).catch(() => false)
+}
+
+async function assertSupportedOnlyInstallOutputs(tmpdir, configHome) {
+  for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
+    const runtimeDir = path.join(tmpdir, INSTALLER_RUNTIME_METADATA[runtime].dirName)
+    expect(await pathExists(runtimeDir), `supported runtime directory should exist: ${runtimeDir}`).toBe(true)
+  }
+
+  expect(await pathExists(path.join(tmpdir, '.gsd', 'knowledge')), 'shared KB should exist').toBe(true)
+  expect(await pathExists(path.join(tmpdir, '.gemini')), '.gemini should not be created by supported-only --all install').toBe(false)
+  expect(await pathExists(path.join(tmpdir, '.opencode')), '.opencode should not be created by supported-only --all install').toBe(false)
+  expect(await pathExists(path.join(configHome, 'opencode')), '.config/opencode should not be created by supported-only --all install').toBe(false)
+}
+
+async function installAllSupported(tmpdir, configHome) {
+  execSync(`node "${installScript}" --all --global`, {
+    env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+    cwd: tmpdir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 30000
+  })
+
+  await assertSupportedOnlyInstallOutputs(tmpdir, configHome)
+}
 
 /** Write a signal fixture file to the shared KB */
 async function writeSignal(kbDir, project, filename, fields = {}) {
@@ -93,12 +124,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('--all install creates shared KB at ~/.gsd/knowledge/', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
       const entries = await fs.readdir(kbDir)
@@ -110,12 +136,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('signal written to shared KB is readable at shared path', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
 
@@ -139,12 +160,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('signal written to shared KB is readable via Claude symlink', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
 
@@ -173,12 +189,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('old-format signal (no runtime/model fields) is readable', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
 
@@ -212,12 +223,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('new-format signal (with runtime/model fields) is readable', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
 
@@ -249,12 +255,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('multiple signals from different runtimes coexist in shared KB', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
       const project = 'multi-runtime-project'
@@ -298,12 +299,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('legacy and split-provenance signals rebuild together in shared KB', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
 
@@ -366,12 +362,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('Claude symlink target resolves to ~/.gsd/knowledge/', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       const claudeKb = path.join(tmpdir, '.claude', 'gsd-knowledge')
       const target = await fs.readlink(claudeKb)
@@ -384,18 +375,11 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('installed workflow files reference .planning/knowledge/ (primary) or ~/.gsd/knowledge/ (fallback), not ~/.claude/gsd-knowledge/', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       // Check each runtime's installed get-shit-done-reflect/ reference docs
       const runtimeDirs = [
         { name: 'claude', dir: path.join(tmpdir, '.claude', 'get-shit-done-reflect') },
-        { name: 'opencode', dir: path.join(configHome, 'opencode', 'get-shit-done-reflect') },
-        { name: 'gemini', dir: path.join(tmpdir, '.gemini', 'get-shit-done-reflect') },
         { name: 'codex', dir: path.join(tmpdir, '.codex', 'get-shit-done-reflect') },
       ]
 
@@ -428,12 +412,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     tmpdirTest('installed agent/workflow files contain .planning/knowledge references', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
       // Check Claude runtime for .planning/knowledge references
       const claudeDir = path.join(tmpdir, '.claude')
@@ -457,23 +436,14 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
   })
 
   describe('v1.14 release readiness', () => {
-    tmpdirTest('all runtimes produce consistent VERSION files', async ({ tmpdir }) => {
+    tmpdirTest('supported runtimes produce consistent VERSION files', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // Read VERSION file from each runtime
-      const versionPaths = [
-        path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'VERSION'),
-        path.join(configHome, 'opencode', 'get-shit-done-reflect', 'VERSION'),
-        path.join(tmpdir, '.gemini', 'get-shit-done-reflect', 'VERSION'),
-        path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'VERSION'),
-      ]
+      const versionPaths = SUPPORTED_INSTALLER_RUNTIMES.map((runtime) =>
+        path.join(tmpdir, INSTALLER_RUNTIME_METADATA[runtime].dirName, 'get-shit-done-reflect', 'VERSION')
+      )
 
       const versions = []
       for (const vp of versionPaths) {
@@ -481,7 +451,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
         versions.push(version)
       }
 
-      // All 4 must match
+      // All supported runtimes must match
       expect(new Set(versions).size).toBe(1)
 
       // Must be a valid semver pattern (major.minor.patch with optional +dev suffix)
@@ -498,19 +468,15 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     // v1.14 Release Readiness -- Phase 17 Validation Coverage
     // =========================================================================
     //
-    // VALID-01: OpenCode install correctness
+    // VALID-01: Supported runtime install correctness
     //   Covered by: tests/integration/multi-runtime.test.js (17-01)
-    //   - OpenCode file layout, path transformation, frontmatter conversion
-    //
-    // VALID-02: Gemini install correctness
-    //   Covered by: tests/integration/multi-runtime.test.js (17-01)
-    //   - Gemini TOML commands, settings.json, path transformation
+    //   - Claude and Codex file layout stays aligned with the supported installer contract
     //
     // VALID-03: Multi-runtime --all install depth
     //   Covered by: tests/integration/multi-runtime.test.js (17-01)
-    //   - All 4 runtimes install correctly with --all --global
-    //   - No leaked Claude paths in non-Claude runtimes
-    //   - KB paths reference ~/.gsd/knowledge/ across all runtimes
+    //   - Only supported runtimes install with --all --global
+    //   - No leaked Claude paths in supported non-Claude runtimes
+    //   - KB paths reference ~/.gsd/knowledge/ across supported runtimes
     //
     // VALID-04: Cross-runtime KB accessibility
     //   Covered by: tests/integration/cross-runtime-kb.test.js (this file, 17-02)
@@ -521,7 +487,7 @@ describe('VALID-04: Cross-runtime KB accessibility', () => {
     //   - New-format signals (with runtime/model) are readable
     //   - Multi-runtime signals coexist in shared KB
     //   - Installed workflow files reference correct KB path
-    //   - VERSION consistency across all 4 runtimes
+    //   - VERSION consistency across supported installer runtimes
     //
     // Release gate: `npx vitest run` must show 0 failures, 100+ tests passing.
     // =========================================================================
@@ -542,19 +508,14 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
     return crypto.createHash('sha256').update(buf).digest('hex')
   }
 
-  function runInstallAll(tmpdir, configHome) {
-    execSync(`node "${installScript}" --all --global`, {
-      env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-      cwd: tmpdir,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      timeout: 60000
-    })
+  async function runInstallAll(tmpdir, configHome) {
+    await installAllSupported(tmpdir, configHome)
   }
 
   describe('sha256 parity: kb* lib modules across runtimes', () => {
     tmpdirTest('kb.cjs, kb-query.cjs, kb-link.cjs, kb-health.cjs, kb-transition.cjs are byte-equal across .claude and .codex', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
-      runInstallAll(tmpdir, configHome)
+      await runInstallAll(tmpdir, configHome)
 
       const libFiles = ['kb.cjs', 'kb-query.cjs', 'kb-link.cjs', 'kb-health.cjs', 'kb-transition.cjs']
       const claudeLibDir = path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'bin', 'lib')
@@ -569,7 +530,7 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
 
     tmpdirTest('knowledge-surfacing.md is byte-equal across .claude and .codex (Phase 59 Plan 05 rewrite parity guard)', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
-      runInstallAll(tmpdir, configHome)
+      await runInstallAll(tmpdir, configHome)
 
       const claudeRef = path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'references', 'knowledge-surfacing.md')
       const codexRef = path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'references', 'knowledge-surfacing.md')
@@ -617,7 +578,7 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
 
     tmpdirTest('kb query --format json produces byte-equal shape across runtimes', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
-      runInstallAll(tmpdir, configHome)
+      await runInstallAll(tmpdir, configHome)
 
       // Seed a project-local KB in tmpdir so the verbs have something concrete to query
       const projectDir = path.join(tmpdir, 'proj')
@@ -656,7 +617,7 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
 
     tmpdirTest('kb search --format json produces byte-equal shape across runtimes', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
-      runInstallAll(tmpdir, configHome)
+      await runInstallAll(tmpdir, configHome)
 
       const projectDir = path.join(tmpdir, 'proj')
       await fs.mkdir(path.join(projectDir, '.planning', 'knowledge', 'signals', 'crosstest'), { recursive: true })
@@ -692,7 +653,7 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
 
     tmpdirTest('kb link show --format json produces byte-equal shape across runtimes', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
-      runInstallAll(tmpdir, configHome)
+      await runInstallAll(tmpdir, configHome)
 
       const projectDir = path.join(tmpdir, 'proj')
       await fs.mkdir(path.join(projectDir, '.planning', 'knowledge', 'signals', 'crosstest'), { recursive: true })
@@ -728,7 +689,7 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
 
     tmpdirTest('kb health --format json produces byte-equal shape across runtimes', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
-      runInstallAll(tmpdir, configHome)
+      await runInstallAll(tmpdir, configHome)
 
       const projectDir = path.join(tmpdir, 'proj')
       await fs.mkdir(path.join(projectDir, '.planning', 'knowledge', 'signals', 'crosstest'), { recursive: true })
@@ -769,7 +730,7 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
       // Transition with no args prints usage; this exercises the dispatch path without
       // actually mutating state (a real dry-run flag is tracked in a later phase).
       const configHome = path.join(tmpdir, '.config')
-      runInstallAll(tmpdir, configHome)
+      await runInstallAll(tmpdir, configHome)
 
       const projectDir = path.join(tmpdir, 'proj')
       await fs.mkdir(path.join(projectDir, '.planning', 'knowledge'), { recursive: true })
@@ -799,4 +760,3 @@ describe('Phase 59 Plan 05: cross-runtime kb* verb parity', () => {
     })
   })
 })
-

--- a/tests/integration/multi-runtime.test.js
+++ b/tests/integration/multi-runtime.test.js
@@ -4,8 +4,16 @@ import path from 'node:path'
 import fs from 'node:fs/promises'
 import fsSync from 'node:fs'
 import { execFileSync, execSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const {
+  INSTALLER_RUNTIME_METADATA,
+  SUPPORTED_INSTALLER_RUNTIMES,
+} = require('../../get-shit-done/bin/lib/runtime-support.cjs')
 
 const installScript = path.resolve(process.cwd(), 'bin/install.js')
+const LEGACY_UNSUPPORTED_INSTALLER_TARGETS = Object.freeze(['opencode', 'gemini'])
 
 function runNodeJson(scriptPath, args, options = {}) {
   const output = execFileSync('node', [scriptPath, ...args], {
@@ -16,111 +24,109 @@ function runNodeJson(scriptPath, args, options = {}) {
   return JSON.parse(output.trim())
 }
 
-// ---------------------------------------------------------------------------
-// Reusable helpers
-// ---------------------------------------------------------------------------
+async function pathExists(targetPath) {
+  return fs.access(targetPath).then(() => true).catch(() => false)
+}
 
-/**
- * Check that a directory exists and contains at least `minCount` entries
- * matching an optional extension filter.
- */
 async function dirHasFiles(dir, extension, minCount) {
-  const exists = await fs.access(dir).then(() => true).catch(() => false)
+  const exists = await pathExists(dir)
   expect(exists, `directory should exist: ${dir}`).toBe(true)
   const entries = await fs.readdir(dir)
   const filtered = extension
-    ? entries.filter(f => f.endsWith(extension))
+    ? entries.filter((entry) => entry.endsWith(extension))
     : entries
   expect(filtered.length, `${dir} should have >= ${minCount} ${extension || ''} files`).toBeGreaterThanOrEqual(minCount)
 }
 
-/**
- * Check that a directory exists and contains at least `minCount` entries
- * whose names match a simple glob pattern (only supports prefix*suffix).
- */
 async function dirHasGlobFiles(dir, pattern, minCount) {
-  const exists = await fs.access(dir).then(() => true).catch(() => false)
+  const exists = await pathExists(dir)
   expect(exists, `directory should exist: ${dir}`).toBe(true)
   const entries = await fs.readdir(dir)
-  // Simple glob: split on * to get prefix and suffix
   const [prefix, suffix] = pattern.split('*')
-  const matched = entries.filter(f => f.startsWith(prefix) && f.endsWith(suffix))
+  const matched = entries.filter((entry) => entry.startsWith(prefix) && entry.endsWith(suffix))
   expect(matched.length, `${dir} should have >= ${minCount} files matching ${pattern}`).toBeGreaterThanOrEqual(minCount)
 }
 
-/**
- * Check that a directory contains at least `minCount` subdirectories matching
- * a simple prefix* pattern.
- */
 async function dirHasGlobDirs(dir, pattern, minCount) {
-  const exists = await fs.access(dir).then(() => true).catch(() => false)
+  const exists = await pathExists(dir)
   expect(exists, `directory should exist: ${dir}`).toBe(true)
   const entries = await fs.readdir(dir, { withFileTypes: true })
   const [prefix] = pattern.split('*')
-  const matched = entries.filter(e => e.isDirectory() && e.name.startsWith(prefix))
+  const matched = entries.filter((entry) => entry.isDirectory() && entry.name.startsWith(prefix))
   expect(matched.length, `${dir} should have >= ${minCount} subdirs matching ${pattern}`).toBeGreaterThanOrEqual(minCount)
 }
 
 async function fileExists(filePath) {
-  const exists = await fs.access(filePath).then(() => true).catch(() => false)
-  expect(exists, `file should exist: ${filePath}`).toBe(true)
+  expect(await pathExists(filePath), `file should exist: ${filePath}`).toBe(true)
 }
 
 async function fileNotExists(filePath) {
-  const exists = await fs.access(filePath).then(() => true).catch(() => false)
-  expect(exists, `file should NOT exist: ${filePath}`).toBe(false)
+  expect(await pathExists(filePath), `file should NOT exist: ${filePath}`).toBe(false)
 }
 
-/**
- * Verify expected directory structure per runtime after installation.
- */
-async function verifyRuntimeLayout(rootDir, runtime, configHome) {
+function getSupportedRuntimeBaseDir(rootDir, runtime) {
+  const metadata = INSTALLER_RUNTIME_METADATA[runtime]
+  if (!metadata) {
+    throw new Error(`Unsupported runtime requested in test helper: ${runtime}`)
+  }
+  return path.join(rootDir, metadata.dirName)
+}
+
+async function verifyRuntimeLayout(rootDir, runtime) {
   if (runtime === 'claude') {
-    const base = path.join(rootDir, '.claude')
+    const base = getSupportedRuntimeBaseDir(rootDir, runtime)
     await dirHasFiles(path.join(base, 'commands', 'gsdr'), '.md', 3)
     await dirHasFiles(path.join(base, 'get-shit-done-reflect'), null, 1)
     await dirHasGlobFiles(path.join(base, 'agents'), 'gsdr-*.md', 1)
     await dirHasFiles(path.join(base, 'hooks'), '.js', 1)
     await fileExists(path.join(base, 'get-shit-done-reflect', 'VERSION'))
     await fileExists(path.join(base, 'settings.json'))
-  } else if (runtime === 'opencode') {
-    const base = configHome
-      ? path.join(configHome, 'opencode')
-      : path.join(rootDir, '.config', 'opencode')
-    await dirHasGlobFiles(path.join(base, 'command'), 'gsdr-*.md', 3)
-    await dirHasFiles(path.join(base, 'get-shit-done-reflect'), null, 1)
-    await dirHasGlobFiles(path.join(base, 'agents'), 'gsdr-*.md', 1)
-    await fileExists(path.join(base, 'get-shit-done-reflect', 'VERSION'))
-  } else if (runtime === 'gemini') {
-    const base = path.join(rootDir, '.gemini')
-    await dirHasFiles(path.join(base, 'commands', 'gsdr'), '.toml', 3)
-    await dirHasFiles(path.join(base, 'get-shit-done-reflect'), null, 1)
-    await dirHasGlobFiles(path.join(base, 'agents'), 'gsdr-*.md', 1)
-    await dirHasFiles(path.join(base, 'hooks'), '.js', 1)
-    await fileExists(path.join(base, 'get-shit-done-reflect', 'VERSION'))
-    await fileExists(path.join(base, 'settings.json'))
-  } else if (runtime === 'codex') {
-    const base = path.join(rootDir, '.codex')
+    return
+  }
+
+  if (runtime === 'codex') {
+    const base = getSupportedRuntimeBaseDir(rootDir, runtime)
     await dirHasGlobDirs(path.join(base, 'skills'), 'gsdr-*', 3)
     await dirHasFiles(path.join(base, 'get-shit-done-reflect'), null, 1)
     await dirHasGlobFiles(path.join(base, 'agents'), 'gsdr-*.toml', 1)
     await fileExists(path.join(base, 'AGENTS.md'))
     await fileExists(path.join(base, 'get-shit-done-reflect', 'VERSION'))
-    // Codex should NOT have these:
     await fileNotExists(path.join(base, 'hooks'))
     await fileNotExists(path.join(base, 'settings.json'))
+    return
   }
+
+  throw new Error(`verifyRuntimeLayout only supports supported runtimes, received: ${runtime}`)
 }
 
-/**
- * Scan all .md and .toml files recursively in runtimeDir and assert no
- * ~/.claude/ paths remain (except in Claude's own install). Also verify
- * KB paths use ~/.gsd/knowledge/ not old ~/.claude/gsd-knowledge/.
- * Returns array of violation objects for detailed failure messages.
- */
+async function verifyUnsupportedRuntimeDirsAbsent(rootDir, configHome) {
+  await fileNotExists(path.join(rootDir, '.gemini'))
+  await fileNotExists(path.join(rootDir, '.opencode'))
+  await fileNotExists(path.join(configHome, 'opencode'))
+}
+
+async function assertSupportedInstallOutputs(rootDir, configHome) {
+  for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
+    await fileExists(getSupportedRuntimeBaseDir(rootDir, runtime))
+  }
+  await fileExists(path.join(rootDir, '.gsd', 'knowledge'))
+  await verifyUnsupportedRuntimeDirsAbsent(rootDir, configHome)
+}
+
+async function installAllSupported(rootDir, configHome) {
+  execSync(`node "${installScript}" --all --global`, {
+    env: { ...process.env, HOME: rootDir, XDG_CONFIG_HOME: configHome },
+    cwd: rootDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 30000,
+  })
+
+  await assertSupportedInstallOutputs(rootDir, configHome)
+}
+
 async function verifyNoLeakedPaths(runtimeDir, runtime) {
   const allFiles = await fs.readdir(runtimeDir, { recursive: true })
-  const textFiles = allFiles.filter(f => f.endsWith('.md') || f.endsWith('.toml'))
+  const textFiles = allFiles.filter((file) => file.endsWith('.md') || file.endsWith('.toml'))
 
   const violations = []
   for (const file of textFiles) {
@@ -130,33 +136,34 @@ async function verifyNoLeakedPaths(runtimeDir, runtime) {
 
     const content = await fs.readFile(filePath, 'utf8')
 
-    // Check for leaked ~/.claude/ paths in non-Claude runtimes
-    // Documentation-style uses (e.g., "~/.claude/ = claude-code") have a space after the slash
-    // and are intentionally preserved by replacePathsInContent()
     if (runtime !== 'claude' && content.includes('~/.claude/')) {
       const lines = content.split('\n')
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].includes('~/.claude/') && !lines[i].match(/~\/\.claude\/\s/)) {
-          violations.push({ file, line: i + 1, issue: 'leaked ~/.claude/ path', text: lines[i].trim() })
+      for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        if (lines[lineIndex].includes('~/.claude/') && !lines[lineIndex].match(/~\/\.claude\/\s/)) {
+          violations.push({
+            file,
+            line: lineIndex + 1,
+            issue: 'leaked ~/.claude/ path',
+            text: lines[lineIndex].trim(),
+          })
         }
       }
     }
 
-    // Check for old gsd-knowledge paths (should be .gsd/knowledge)
     if (content.includes('gsd-knowledge') && !content.includes('.gsd/knowledge')) {
       violations.push({ file, issue: 'uses old gsd-knowledge path instead of .gsd/knowledge' })
     }
 
-    // Check for stale gsd- references that should be gsdr- in installed output
-    // Exempt: gsd-tools.cjs (filename preserved), gsd-knowledge (legacy KB path),
-    //         CHANGELOG.md (historical references to old agent names),
-    //         gsd-test (temp directory names from test harness),
-    //         gsd-build (upstream GitHub org name)
     if (!file.endsWith('CHANGELOG.md') && content.match(/\bgsd-(?!tools|knowledge|test|build)/)) {
       const lines = content.split('\n')
-      for (let i = 0; i < lines.length; i++) {
-        if (lines[i].match(/\bgsd-(?!tools|knowledge|test|build)/) && !lines[i].includes('gsdr-')) {
-          violations.push({ file, line: i + 1, issue: 'stale gsd- reference (should be gsdr-)', text: lines[i].trim() })
+      for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+        if (lines[lineIndex].match(/\bgsd-(?!tools|knowledge|test|build)/) && !lines[lineIndex].includes('gsdr-')) {
+          violations.push({
+            file,
+            line: lineIndex + 1,
+            issue: 'stale gsd- reference (should be gsdr-)',
+            text: lines[lineIndex].trim(),
+          })
         }
       }
     }
@@ -165,13 +172,9 @@ async function verifyNoLeakedPaths(runtimeDir, runtime) {
   expect(violations, `Path leakage violations in ${runtime}:\n${JSON.stringify(violations, null, 2)}`).toHaveLength(0)
 }
 
-/**
- * Scan installed files for any reference to 'knowledge' and verify they
- * use .planning/knowledge/ (project-local primary) or ~/.gsd/knowledge/ (fallback).
- */
 async function verifyKBPathsShared(runtimeDir) {
   const allFiles = await fs.readdir(runtimeDir, { recursive: true })
-  const textFiles = allFiles.filter(f => f.endsWith('.md') || f.endsWith('.toml'))
+  const textFiles = allFiles.filter((file) => file.endsWith('.md') || file.endsWith('.toml'))
 
   const violations = []
   for (const file of textFiles) {
@@ -180,231 +183,91 @@ async function verifyKBPathsShared(runtimeDir) {
     if (!stat.isFile()) continue
 
     const content = await fs.readFile(filePath, 'utf8')
-
-    // If file references 'gsd-knowledge' or 'gsd_knowledge', it should use
-    // .planning/knowledge (project-local) or .gsd/knowledge (user-global fallback)
-    if (content.includes('gsd-knowledge') || content.includes('gsd_knowledge')) {
-      if (!content.includes('.gsd/knowledge') && !content.includes('.planning/knowledge')) {
-        violations.push({ file, issue: 'references gsd-knowledge but not via .planning/knowledge/ or .gsd/knowledge/' })
-      }
+    if ((content.includes('gsd-knowledge') || content.includes('gsd_knowledge')) &&
+      !content.includes('.gsd/knowledge') &&
+      !content.includes('.planning/knowledge')
+    ) {
+      violations.push({
+        file,
+        issue: 'references gsd-knowledge but not via .planning/knowledge/ or .gsd/knowledge/',
+      })
     }
   }
 
   expect(violations, `KB path violations:\n${JSON.stringify(violations, null, 2)}`).toHaveLength(0)
 }
 
-// ---------------------------------------------------------------------------
-// VALID-01: OpenCode Installation
-// ---------------------------------------------------------------------------
-
 describe('multi-runtime validation', () => {
-  describe('VALID-01: OpenCode installation', () => {
-    tmpdirTest('OpenCode: correct file layout after install', async ({ tmpdir }) => {
-      const configHome = path.join(tmpdir, '.config')
-
-      execSync(`node "${installScript}" --opencode --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+  describe('supported runtime installs', () => {
+    tmpdirTest('Claude: correct file layout after install', async ({ tmpdir }) => {
+      execSync(`node "${installScript}" --claude --global`, {
+        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: path.join(tmpdir, '.config') },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        timeout: 15000,
       })
 
-      await verifyRuntimeLayout(tmpdir, 'opencode', configHome)
+      await verifyRuntimeLayout(tmpdir, 'claude')
+      await verifyUnsupportedRuntimeDirsAbsent(tmpdir, path.join(tmpdir, '.config'))
     })
 
-    tmpdirTest('OpenCode: all paths transformed from ~/.claude/ to XDG path', async ({ tmpdir }) => {
-      const configHome = path.join(tmpdir, '.config')
-
-      execSync(`node "${installScript}" --opencode --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+    tmpdirTest('Codex: correct file layout after install', async ({ tmpdir }) => {
+      execSync(`node "${installScript}" --codex --global`, {
+        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: path.join(tmpdir, '.config') },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        timeout: 15000,
       })
 
-      const opcodeDir = path.join(configHome, 'opencode')
-      await verifyNoLeakedPaths(opcodeDir, 'opencode')
+      await verifyRuntimeLayout(tmpdir, 'codex')
+      await verifyUnsupportedRuntimeDirsAbsent(tmpdir, path.join(tmpdir, '.config'))
     })
 
-    tmpdirTest('OpenCode: command files use flat gsdr-*.md naming', async ({ tmpdir }) => {
-      const configHome = path.join(tmpdir, '.config')
-
-      execSync(`node "${installScript}" --opencode --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+    tmpdirTest('Codex: installed files use shared KB paths and do not leak Claude runtime paths', async ({ tmpdir }) => {
+      execSync(`node "${installScript}" --codex --global`, {
+        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: path.join(tmpdir, '.config') },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        timeout: 15000,
       })
 
-      const commandDir = path.join(configHome, 'opencode', 'command')
-      const files = await fs.readdir(commandDir)
-
-      // All GSD command files should be gsdr-*.md (flat, no nested gsdr/ subdirectory)
-      const gsdFiles = files.filter(f => f.startsWith('gsdr-') && f.endsWith('.md'))
-      expect(gsdFiles.length).toBeGreaterThanOrEqual(3)
-
-      // There should be NO gsdr/ subdirectory inside command/
-      const gsdSubdir = await fs.access(path.join(commandDir, 'gsdr')).then(() => true).catch(() => false)
-      expect(gsdSubdir, 'command/gsdr/ subdirectory should NOT exist (flat structure)').toBe(false)
-
-      // Every file in the command dir that starts with gsdr- should be .md
-      for (const file of gsdFiles) {
-        expect(file).toMatch(/^gsdr-.*\.md$/)
-      }
-    })
-
-    tmpdirTest('OpenCode: KB paths reference .planning/knowledge/ (primary) or ~/.gsd/knowledge/ (fallback)', async ({ tmpdir }) => {
-      const configHome = path.join(tmpdir, '.config')
-
-      execSync(`node "${installScript}" --opencode --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
-      })
-
-      const opcodeDir = path.join(configHome, 'opencode')
-      await verifyKBPathsShared(opcodeDir)
+      const codexDir = getSupportedRuntimeBaseDir(tmpdir, 'codex')
+      await verifyNoLeakedPaths(codexDir, 'codex')
+      await verifyKBPathsShared(codexDir)
+      await verifyUnsupportedRuntimeDirsAbsent(tmpdir, path.join(tmpdir, '.config'))
     })
   })
 
-  // ---------------------------------------------------------------------------
-  // VALID-02: Gemini Installation
-  // ---------------------------------------------------------------------------
+  describe('legacy unsupported installer targets', () => {
+    for (const runtime of LEGACY_UNSUPPORTED_INSTALLER_TARGETS) {
+      tmpdirTest(`${runtime}: explicit legacy runtime flag exits with guidance and creates no runtime output`, async ({ tmpdir }) => {
+        const configHome = path.join(tmpdir, '.config')
+        let error
 
-  describe('VALID-02: Gemini installation', () => {
-    tmpdirTest('Gemini: correct file layout after install', async ({ tmpdir }) => {
-      execSync(`node "${installScript}" --gemini --global`, {
-        env: { ...process.env, HOME: tmpdir },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        try {
+          execSync(`node "${installScript}" --${runtime} --global`, {
+            env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+            cwd: tmpdir,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            timeout: 15000,
+          })
+        } catch (caught) {
+          error = caught
+        }
+
+        expect(error, `--${runtime} should exit non-zero`).toBeTruthy()
+        expect(error.status).not.toBe(0)
+        const stderr = error.stderr?.toString() || ''
+        expect(stderr).toContain(`--${runtime}`)
+        expect(stderr).toContain('--all for all supported runtimes')
+        expect(stderr).toContain('Legacy Gemini/OpenCode installer support has been removed')
+
+        await fileNotExists(getSupportedRuntimeBaseDir(tmpdir, 'claude'))
+        await fileNotExists(getSupportedRuntimeBaseDir(tmpdir, 'codex'))
+        await verifyUnsupportedRuntimeDirsAbsent(tmpdir, configHome)
       })
-
-      await verifyRuntimeLayout(tmpdir, 'gemini')
-    })
-
-    tmpdirTest('Gemini: all paths transformed from ~/.claude/ to ~/.gemini/', async ({ tmpdir }) => {
-      execSync(`node "${installScript}" --gemini --global`, {
-        env: { ...process.env, HOME: tmpdir },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
-      })
-
-      const geminiDir = path.join(tmpdir, '.gemini')
-      await verifyNoLeakedPaths(geminiDir, 'gemini')
-    })
-
-    tmpdirTest('Gemini: command files are .toml format', async ({ tmpdir }) => {
-      execSync(`node "${installScript}" --gemini --global`, {
-        env: { ...process.env, HOME: tmpdir },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
-      })
-
-      const commandsDir = path.join(tmpdir, '.gemini', 'commands', 'gsdr')
-      const files = await fs.readdir(commandsDir)
-
-      // All command files should be .toml, NOT .md
-      const tomlFiles = files.filter(f => f.endsWith('.toml'))
-      const mdFiles = files.filter(f => f.endsWith('.md'))
-
-      expect(tomlFiles.length).toBeGreaterThanOrEqual(3)
-      expect(mdFiles.length, 'no .md files should be in Gemini commands/gsdr/').toBe(0)
-
-      // Verify at least one .toml file has valid TOML-like content
-      const sampleToml = await fs.readFile(path.join(commandsDir, tomlFiles[0]), 'utf8')
-      expect(sampleToml).toContain('prompt = ')
-    })
-
-    tmpdirTest('Gemini: KB paths reference .planning/knowledge/ (primary) or ~/.gsd/knowledge/ (fallback)', async ({ tmpdir }) => {
-      execSync(`node "${installScript}" --gemini --global`, {
-        env: { ...process.env, HOME: tmpdir },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
-      })
-
-      const geminiDir = path.join(tmpdir, '.gemini')
-      await verifyKBPathsShared(geminiDir)
-    })
-
-    tmpdirTest('Gemini: agent files retain MCP tool references after install', async ({ tmpdir }) => {
-      execSync(`node "${installScript}" --gemini --global`, {
-        env: { ...process.env, HOME: tmpdir },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
-      })
-
-      // Read the installed planner agent (source has mcp__context7__* in tools)
-      const plannerAgent = path.join(tmpdir, '.gemini', 'agents', 'gsdr-planner.md')
-      const content = await fs.readFile(plannerAgent, 'utf8')
-
-      // MCP tool reference should be preserved, not stripped
-      expect(content).toContain('mcp__context7')
-    })
-
-    tmpdirTest('Gemini: ALL agent body text uses Gemini-native tool names', async ({ tmpdir }) => {
-      execSync(`node "${installScript}" --gemini --global`, {
-        env: { ...process.env, HOME: tmpdir },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
-      })
-
-      const agentsDir = path.join(tmpdir, '.gemini', 'agents')
-      const agentFiles = (await fs.readdir(agentsDir)).filter(f => f.startsWith('gsdr-') && f.endsWith('.md'))
-
-      expect(agentFiles.length, 'should have multiple agent files').toBeGreaterThanOrEqual(3)
-
-      for (const agentFile of agentFiles) {
-        const content = await fs.readFile(path.join(agentsDir, agentFile), 'utf8')
-        const parts = content.split('---')
-        const body = parts.slice(2).join('---')
-
-        // Body text should NOT contain Claude tool names (word-boundary match)
-        expect(body, `${agentFile}: should not contain \\bRead\\b`).not.toMatch(/\bRead\b/)
-        expect(body, `${agentFile}: should not contain \\bBash\\b`).not.toMatch(/\bBash\b/)
-        expect(body, `${agentFile}: should not contain \\bWrite\\b`).not.toMatch(/\bWrite\b/)
-        expect(body, `${agentFile}: should not contain \\bGlob\\b`).not.toMatch(/\bGlob\b/)
-        expect(body, `${agentFile}: should not contain \\bGrep\\b`).not.toMatch(/\bGrep\b/)
-      }
-    })
-
-    tmpdirTest('Gemini: agent body text uses Gemini-native tool names after install', async ({ tmpdir }) => {
-      execSync(`node "${installScript}" --gemini --global`, {
-        env: { ...process.env, HOME: tmpdir },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
-      })
-
-      // Read the installed planner agent (body references Read, Write, Bash, Glob, Grep)
-      const plannerAgent = path.join(tmpdir, '.gemini', 'agents', 'gsdr-planner.md')
-      const content = await fs.readFile(plannerAgent, 'utf8')
-
-      // Separate frontmatter from body for body-only assertions
-      const parts = content.split('---')
-      const body = parts.slice(2).join('---')
-
-      // Body text should contain Gemini-native tool names
-      expect(body).toContain('read_file')
-      // Body text should NOT contain Claude tool names (word-boundary match)
-      expect(body).not.toMatch(/\bRead\b/)
-      expect(body).not.toMatch(/\bBash\b/)
-      // MCP references should still be preserved in body if present
-      if (body.includes('mcp__')) {
-        expect(body).toMatch(/mcp__\w+__/)
-      }
-    })
+    }
   })
-
-  // ---------------------------------------------------------------------------
-  // Codex MCP config.toml after install
-  // ---------------------------------------------------------------------------
 
   describe('Codex MCP config.toml after install', () => {
     tmpdirTest('Codex install generates config.toml with MCP servers', async ({ tmpdir }) => {
@@ -412,11 +275,11 @@ describe('multi-runtime validation', () => {
         env: { ...process.env, HOME: tmpdir },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        timeout: 15000,
       })
 
       const configTomlPath = path.join(tmpdir, '.codex', 'config.toml')
-      const exists = await fs.access(configTomlPath).then(() => true).catch(() => false)
+      const exists = await pathExists(configTomlPath)
       expect(exists, 'config.toml should exist after Codex install').toBe(true)
 
       const content = await fs.readFile(configTomlPath, 'utf8')
@@ -428,14 +291,10 @@ describe('multi-runtime validation', () => {
       expect(content).toContain('# GSD:BEGIN (get-shit-done-reflect-cc)')
       expect(content).toContain('# GSD:END (get-shit-done-reflect-cc)')
 
-      const promptExists = await fs.access(compactPromptPath).then(() => true).catch(() => false)
+      const promptExists = await pathExists(compactPromptPath)
       expect(promptExists, 'codex compact prompt file should exist after Codex install').toBe(true)
     })
   })
-
-  // ---------------------------------------------------------------------------
-  // Codex agent TOML literal string safety
-  // ---------------------------------------------------------------------------
 
   describe('Codex agent TOML literal string safety', () => {
     tmpdirTest('Codex agent TOML files use literal strings for backslash safety', async ({ tmpdir }) => {
@@ -443,175 +302,72 @@ describe('multi-runtime validation', () => {
         env: { ...process.env, HOME: tmpdir },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        timeout: 15000,
       })
 
-      // Read the verifier agent (highest backslash density)
       const verifierPath = path.join(tmpdir, '.codex', 'agents', 'gsdr-verifier.toml')
-      const exists = await fs.access(verifierPath).then(() => true).catch(() => false)
+      const exists = await pathExists(verifierPath)
       expect(exists, 'gsdr-verifier.toml should exist after Codex install').toBe(true)
 
       const content = await fs.readFile(verifierPath, 'utf8')
-
-      // Must use literal string delimiters ('''), not basic string delimiters (""")
       expect(content).toContain("developer_instructions = '''")
       expect(content).not.toContain('developer_instructions = """')
-
-      // Must contain actual agent content (not empty)
       expect(content).toContain('description = ')
       expect(content.length).toBeGreaterThan(100)
     })
   })
 
-  // ---------------------------------------------------------------------------
-  // VALID-03: Multi-runtime --all install (added in Task 2)
-  // ---------------------------------------------------------------------------
-
   describe('VALID-03: Multi-runtime --all install', () => {
-    tmpdirTest('--all installs all 4 runtimes with correct file layouts', async ({ tmpdir }) => {
+    tmpdirTest('--all installs only supported runtimes with correct file layouts', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
-
-      // Verify all 4 runtimes have correct file layouts
-      await verifyRuntimeLayout(tmpdir, 'claude')
-      await verifyRuntimeLayout(tmpdir, 'opencode', configHome)
-      await verifyRuntimeLayout(tmpdir, 'gemini')
-      await verifyRuntimeLayout(tmpdir, 'codex')
-    })
-
-    tmpdirTest('--all install: no cross-runtime path leakage', async ({ tmpdir }) => {
-      const configHome = path.join(tmpdir, '.config')
-
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
-
-      // For each non-Claude runtime, verify no ~/.claude/ paths leaked
-      const opcodeDir = path.join(configHome, 'opencode')
-      await verifyNoLeakedPaths(opcodeDir, 'opencode')
-
-      const geminiDir = path.join(tmpdir, '.gemini')
-      await verifyNoLeakedPaths(geminiDir, 'gemini')
-
-      const codexDir = path.join(tmpdir, '.codex')
-      await verifyNoLeakedPaths(codexDir, 'codex')
-
-      // Verify each runtime's installed files reference the correct runtime-specific prefix
-      // OpenCode: should use ~/.config/opencode/
-      const opcodeGsd = path.join(opcodeDir, 'get-shit-done-reflect')
-      const opcodeFiles = await fs.readdir(opcodeGsd, { recursive: true })
-      const opcodeMdFiles = opcodeFiles.filter(f => f.endsWith('.md'))
-      for (const file of opcodeMdFiles) {
-        const filePath = path.join(opcodeGsd, file)
-        const stat = await fs.stat(filePath)
-        if (!stat.isFile()) continue
-        const content = await fs.readFile(filePath, 'utf8')
-        // If file references get-shit-done paths, they should use opencode path
-        if (content.includes('/get-shit-done-reflect/') && !content.includes('.gsd/knowledge')) {
-          expect(content).not.toContain('~/.claude/get-shit-done')
-        }
-      }
-
-      // Gemini: should use ~/.gemini/
-      const geminiGsd = path.join(geminiDir, 'get-shit-done-reflect')
-      const geminiFiles = await fs.readdir(geminiGsd, { recursive: true })
-      const geminiMdFiles = geminiFiles.filter(f => f.endsWith('.md'))
-      for (const file of geminiMdFiles) {
-        const filePath = path.join(geminiGsd, file)
-        const stat = await fs.stat(filePath)
-        if (!stat.isFile()) continue
-        const content = await fs.readFile(filePath, 'utf8')
-        if (content.includes('/get-shit-done-reflect/') && !content.includes('.gsd/knowledge')) {
-          expect(content).not.toContain('~/.claude/get-shit-done')
-        }
-      }
-
-      // Codex: should use ~/.codex/
-      const codexGsd = path.join(codexDir, 'get-shit-done-reflect')
-      const codexFiles = await fs.readdir(codexGsd, { recursive: true })
-      const codexMdFiles = codexFiles.filter(f => f.endsWith('.md'))
-      for (const file of codexMdFiles) {
-        const filePath = path.join(codexGsd, file)
-        const stat = await fs.stat(filePath)
-        if (!stat.isFile()) continue
-        const content = await fs.readFile(filePath, 'utf8')
-        if (content.includes('/get-shit-done-reflect/') && !content.includes('.gsd/knowledge')) {
-          expect(content).not.toContain('~/.claude/get-shit-done')
-        }
+      await installAllSupported(tmpdir, configHome)
+      for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
+        await verifyRuntimeLayout(tmpdir, runtime)
       }
     })
 
-    tmpdirTest('--all install: each runtime has format-correct command files', async ({ tmpdir }) => {
+    tmpdirTest('--all install: supported runtime files reference shared KB paths without unsupported output dirs', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // Claude: .md files in commands/gsdr/
+      await verifyKBPathsShared(getSupportedRuntimeBaseDir(tmpdir, 'claude'))
+      await verifyKBPathsShared(getSupportedRuntimeBaseDir(tmpdir, 'codex'))
+      await verifyNoLeakedPaths(getSupportedRuntimeBaseDir(tmpdir, 'codex'), 'codex')
+      await verifyUnsupportedRuntimeDirsAbsent(tmpdir, configHome)
+    })
+
+    tmpdirTest('--all install: each supported runtime has format-correct command files', async ({ tmpdir }) => {
+      const configHome = path.join(tmpdir, '.config')
+
+      await installAllSupported(tmpdir, configHome)
+
       const claudeCommandsDir = path.join(tmpdir, '.claude', 'commands', 'gsdr')
       const claudeFiles = await fs.readdir(claudeCommandsDir)
-      const claudeMdFiles = claudeFiles.filter(f => f.endsWith('.md'))
+      const claudeMdFiles = claudeFiles.filter((file) => file.endsWith('.md'))
       expect(claudeMdFiles.length).toBeGreaterThanOrEqual(3)
 
-      // OpenCode: .md files matching gsdr-*.md in command/ (flat)
-      const opcodeCommandDir = path.join(configHome, 'opencode', 'command')
-      const opcodeFiles = await fs.readdir(opcodeCommandDir)
-      const opcodeGsdFiles = opcodeFiles.filter(f => f.startsWith('gsdr-') && f.endsWith('.md'))
-      expect(opcodeGsdFiles.length).toBeGreaterThanOrEqual(3)
-
-      // Gemini: .toml files in commands/gsdr/
-      const geminiCommandsDir = path.join(tmpdir, '.gemini', 'commands', 'gsdr')
-      const geminiFiles = await fs.readdir(geminiCommandsDir)
-      const geminiTomlFiles = geminiFiles.filter(f => f.endsWith('.toml'))
-      expect(geminiTomlFiles.length).toBeGreaterThanOrEqual(3)
-      // No .md files should be in Gemini commands
-      const geminiMdFiles = geminiFiles.filter(f => f.endsWith('.md'))
-      expect(geminiMdFiles.length).toBe(0)
-
-      // Codex: SKILL.md files in skills/gsdr-*/
       const codexSkillsDir = path.join(tmpdir, '.codex', 'skills')
       const codexEntries = await fs.readdir(codexSkillsDir, { withFileTypes: true })
-      const codexSkillDirs = codexEntries.filter(e => e.isDirectory() && e.name.startsWith('gsdr-'))
+      const codexSkillDirs = codexEntries.filter((entry) => entry.isDirectory() && entry.name.startsWith('gsdr-'))
       expect(codexSkillDirs.length).toBeGreaterThanOrEqual(3)
 
-      // Verify each Codex skill has a SKILL.md
       for (const skillDir of codexSkillDirs) {
-        const skillMdPath = path.join(codexSkillsDir, skillDir.name, 'SKILL.md')
-        const exists = await fs.access(skillMdPath).then(() => true).catch(() => false)
-        expect(exists, `${skillDir.name}/SKILL.md should exist`).toBe(true)
+        await fileExists(path.join(codexSkillsDir, skillDir.name, 'SKILL.md'))
       }
     })
 
     tmpdirTest('--all install: shared KB directory created with correct structure', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // Verify ~/.gsd/knowledge/ directory exists with signals/, spikes/, lessons/
       const kbDir = path.join(tmpdir, '.gsd', 'knowledge')
       await fileExists(path.join(kbDir, 'signals'))
       await fileExists(path.join(kbDir, 'spikes'))
       await fileExists(path.join(kbDir, 'lessons'))
 
-      // Verify Claude backward-compat symlink
       const claudeSymlink = path.join(tmpdir, '.claude', 'gsd-knowledge')
       const stat = await fs.lstat(claudeSymlink)
       expect(stat.isSymbolicLink()).toBe(true)
@@ -620,159 +376,73 @@ describe('multi-runtime validation', () => {
       expect(target).toBe(kbDir)
     })
 
-    tmpdirTest('--all install: file name parity across runtimes per category', async ({ tmpdir }) => {
+    tmpdirTest('--all install: file name parity across supported runtimes per category', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      /**
-       * Helper: read directory, filter by pattern, strip extensions, return sorted Set.
-       */
       function getNameSet(dir, prefix, suffix) {
         if (!fsSync.existsSync(dir)) return new Set()
         const entries = fsSync.readdirSync(dir)
-        const matched = entries.filter(f => f.startsWith(prefix) && f.endsWith(suffix))
-        return new Set(matched.map(f => {
-          // Strip extension (last .xxx)
-          const lastDot = f.lastIndexOf('.')
-          return lastDot > 0 ? f.substring(0, lastDot) : f
-        }))
+        const matched = entries.filter((entry) => entry.startsWith(prefix) && entry.endsWith(suffix))
+        return new Set(matched.map((entry) => entry.substring(0, entry.lastIndexOf('.'))))
       }
 
-      /**
-       * Helper: get directory names matching prefix.
-       */
       function getDirNameSet(dir, prefix) {
         if (!fsSync.existsSync(dir)) return new Set()
         const entries = fsSync.readdirSync(dir, { withFileTypes: true })
-        return new Set(
-          entries.filter(e => e.isDirectory() && e.name.startsWith(prefix)).map(e => e.name)
-        )
+        return new Set(entries.filter((entry) => entry.isDirectory() && entry.name.startsWith(prefix)).map((entry) => entry.name))
       }
 
-      // Known intentional divergences (empty = no exceptions expected)
-      const exceptions = {
-        agents: [],
-        commands: [],
-        workflows: [],
-        hooks: []
-      }
-
-      // --- Agents: All 4 runtimes (Codex uses .toml, others use .md) ---
       const claudeAgents = getNameSet(path.join(tmpdir, '.claude', 'agents'), 'gsdr-', '.md')
-      const opcodeAgents = getNameSet(path.join(configHome, 'opencode', 'agents'), 'gsdr-', '.md')
-      const geminiAgents = getNameSet(path.join(tmpdir, '.gemini', 'agents'), 'gsdr-', '.md')
       const codexAgents = getNameSet(path.join(tmpdir, '.codex', 'agents'), 'gsdr-', '.toml')
-
-      expect([...claudeAgents].sort(), 'Agent parity: Claude vs OpenCode').toEqual([...opcodeAgents].sort())
-      expect([...claudeAgents].sort(), 'Agent parity: Claude vs Gemini').toEqual([...geminiAgents].sort())
       expect([...claudeAgents].sort(), 'Agent parity: Claude vs Codex').toEqual([...codexAgents].sort())
 
-      // --- Workflows: All 4 runtimes use .md (Gemini no longer TOML-converts non-command files) ---
       const claudeWorkflows = getNameSet(path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'workflows'), '', '.md')
-      const opcodeWorkflows = getNameSet(path.join(configHome, 'opencode', 'get-shit-done-reflect', 'workflows'), '', '.md')
-      const geminiWorkflows = getNameSet(path.join(tmpdir, '.gemini', 'get-shit-done-reflect', 'workflows'), '', '.md')
       const codexWorkflows = getNameSet(path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'workflows'), '', '.md')
-
-      expect([...claudeWorkflows].sort(), 'Workflow parity: Claude vs OpenCode').toEqual([...opcodeWorkflows].sort())
-      expect([...claudeWorkflows].sort(), 'Workflow parity: Claude vs Gemini').toEqual([...geminiWorkflows].sort())
       expect([...claudeWorkflows].sort(), 'Workflow parity: Claude vs Codex').toEqual([...codexWorkflows].sort())
 
-      // --- Commands: different naming per runtime, compare extension-stripped ---
-      // Claude: commands/gsdr/*.md (strip leading path, keep name only)
       const claudeCommands = getNameSet(path.join(tmpdir, '.claude', 'commands', 'gsdr'), '', '.md')
-      // OpenCode: command/gsdr-*.md
-      const opcodeCommands = getNameSet(path.join(configHome, 'opencode', 'command'), 'gsdr-', '.md')
-      // Gemini: commands/gsdr/*.toml
-      const geminiCommands = getNameSet(path.join(tmpdir, '.gemini', 'commands', 'gsdr'), '', '.toml')
-      // Codex: skills/gsdr-*/ (directory names)
       const codexCommands = getDirNameSet(path.join(tmpdir, '.codex', 'skills'), 'gsdr-')
-
-      // Normalize: Claude and Gemini commands lack gsdr- prefix (nested in gsdr/ subdir),
-      // while OpenCode and Codex have gsdr- prefix (flat naming). Add gsdr- prefix to normalize.
-      function addGsdPrefix(nameSet) {
-        return new Set([...nameSet].map(n => n.startsWith('gsdr-') ? n : `gsdr-${n}`))
-      }
-      const claudeNorm = addGsdPrefix(claudeCommands)
-      const geminiNorm = addGsdPrefix(geminiCommands)
-
-      expect([...claudeNorm].sort(), 'Command parity: Claude vs OpenCode').toEqual([...opcodeCommands].sort())
-      expect([...claudeNorm].sort(), 'Command parity: Claude vs Gemini').toEqual([...geminiNorm].sort())
-      expect([...claudeNorm].sort(), 'Command parity: Claude vs Codex').toEqual([...codexCommands].sort())
-
-      // --- Hooks: Claude, OpenCode, Gemini (Codex excluded -- no hooks) ---
-      const claudeHooks = getNameSet(path.join(tmpdir, '.claude', 'hooks'), 'gsdr-', '.js')
-      const opcodeHooks = getNameSet(path.join(configHome, 'opencode', 'hooks'), 'gsdr-', '.js')
-      const geminiHooks = getNameSet(path.join(tmpdir, '.gemini', 'hooks'), 'gsdr-', '.js')
-
-      expect([...claudeHooks].sort(), 'Hook parity: Claude vs OpenCode').toEqual([...opcodeHooks].sort())
-      expect([...claudeHooks].sort(), 'Hook parity: Claude vs Gemini').toEqual([...geminiHooks].sort())
+      const normalizedClaudeCommands = new Set([...claudeCommands].map((name) => (name.startsWith('gsdr-') ? name : `gsdr-${name}`)))
+      expect([...normalizedClaudeCommands].sort(), 'Command parity: Claude vs Codex').toEqual([...codexCommands].sort())
     })
 
-    tmpdirTest('--all install: hook files match hook registrations in settings.json', async ({ tmpdir }) => {
+    tmpdirTest('--all install: hook registrations remain Claude-only and Codex stays hook-free', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // For Claude and Gemini: validate settings.json hook registrations match actual hook files
-      const runtimes = [
-        { name: 'Claude', settingsPath: path.join(tmpdir, '.claude', 'settings.json'), hooksDir: path.join(tmpdir, '.claude', 'hooks') },
-        { name: 'Gemini', settingsPath: path.join(tmpdir, '.gemini', 'settings.json'), hooksDir: path.join(tmpdir, '.gemini', 'hooks') },
-      ]
-
-      for (const rt of runtimes) {
-        const settings = JSON.parse(await fs.readFile(rt.settingsPath, 'utf8'))
-
-        // Extract hook filenames from settings.json hook commands
-        // Structure: hooks.EventType[] -> { hooks: [{ type, command }] }
-        const registeredHooks = new Set()
-        const hooks = settings.hooks || {}
-        for (const eventType of Object.keys(hooks)) {
-          const eventHooks = hooks[eventType]
-          if (!Array.isArray(eventHooks)) continue
-          for (const hookEntry of eventHooks) {
-            // Each hookEntry has a nested hooks array with {type, command}
-            const innerHooks = hookEntry.hooks || []
-            for (const inner of innerHooks) {
-              const command = inner.command || ''
-              const match = command.match(/gsdr-[\w-]+\.js/)
-              if (match) registeredHooks.add(match[0])
-            }
-            // Also check direct command (in case structure varies)
-            const directCommand = hookEntry.command || ''
-            const directMatch = directCommand.match(/gsdr-[\w-]+\.js/)
-            if (directMatch) registeredHooks.add(directMatch[0])
+      const settings = JSON.parse(await fs.readFile(path.join(tmpdir, '.claude', 'settings.json'), 'utf8'))
+      const registeredHooks = new Set()
+      const hooks = settings.hooks || {}
+      for (const eventType of Object.keys(hooks)) {
+        const eventHooks = hooks[eventType]
+        if (!Array.isArray(eventHooks)) continue
+        for (const hookEntry of eventHooks) {
+          const innerHooks = hookEntry.hooks || []
+          for (const inner of innerHooks) {
+            const command = inner.command || ''
+            const match = command.match(/gsdr-[\w-]+\.js/)
+            if (match) registeredHooks.add(match[0])
           }
+          const directCommand = hookEntry.command || ''
+          const directMatch = directCommand.match(/gsdr-[\w-]+\.js/)
+          if (directMatch) registeredHooks.add(directMatch[0])
         }
-
-        // Collect actual hook files
-        const actualHookFiles = (await fs.readdir(rt.hooksDir))
-          .filter(f => f.startsWith('gsdr-') && f.endsWith('.js'))
-        const actualHookSet = new Set(actualHookFiles)
-
-        // Every registered hook must have a corresponding file
-        // (catches: settings.json references a hook that wasn't built/copied)
-        for (const registered of registeredHooks) {
-          expect(actualHookSet.has(registered), `${rt.name}: registered hook ${registered} should have corresponding file`).toBe(true)
-        }
-
-        // At least one hook should be registered (sanity check)
-        expect(registeredHooks.size, `${rt.name}: should have at least 1 registered hook`).toBeGreaterThanOrEqual(1)
-
-        // Note: not all hook files need settings.json registration (e.g., gsd-statusline.js
-        // is a notification hook invoked via a different mechanism). We only assert the
-        // "registered -> file exists" direction to catch the build-hooks.js sync bug class.
       }
+
+      const actualHookFiles = (await fs.readdir(path.join(tmpdir, '.claude', 'hooks')))
+        .filter((file) => file.startsWith('gsdr-') && file.endsWith('.js'))
+      const actualHookSet = new Set(actualHookFiles)
+
+      for (const registered of registeredHooks) {
+        expect(actualHookSet.has(registered), `Claude: registered hook ${registered} should have corresponding file`).toBe(true)
+      }
+
+      expect(registeredHooks.size, 'Claude: should have at least 1 registered hook').toBeGreaterThanOrEqual(1)
+      await fileNotExists(path.join(tmpdir, '.codex', 'hooks'))
+      await fileNotExists(path.join(tmpdir, '.codex', 'settings.json'))
     })
 
     tmpdirTest('Codex writer provenance prefers installed harness VERSION over repo mirror', async ({ tmpdir }) => {
@@ -782,7 +452,7 @@ describe('multi-runtime validation', () => {
         env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
+        timeout: 30000,
       })
 
       const projectDir = path.join(tmpdir, 'project')
@@ -791,17 +461,17 @@ describe('multi-runtime validation', () => {
       await fs.writeFile(
         path.join(projectDir, '.planning', 'config.json'),
         JSON.stringify({ model_profile: 'quality', gsd_reflect_version: '9.9.9-config' }),
-        'utf8'
+        'utf8',
       )
       await fs.writeFile(
         path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION'),
         '0.0.1-stale\n',
-        'utf8'
+        'utf8',
       )
 
       const installedVersion = (await fs.readFile(
         path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'VERSION'),
-        'utf8'
+        'utf8',
       )).trim()
       const provenancePath = path.resolve(process.cwd(), 'get-shit-done/bin/lib/provenance.cjs')
 
@@ -811,8 +481,8 @@ describe('multi-runtime validation', () => {
           env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome, CODEX_THREAD_ID: 'thread-test' },
           cwd: projectDir,
           encoding: 'utf8',
-          timeout: 30000
-        }
+          timeout: 30000,
+        },
       )
 
       const parsed = JSON.parse(output.trim())
@@ -828,21 +498,13 @@ describe('multi-runtime validation', () => {
         env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
+        timeout: 30000,
       })
 
       const projectDir = path.join(tmpdir, 'project')
       await fs.mkdir(path.join(projectDir, '.codex', 'get-shit-done-reflect'), { recursive: true })
-      await fs.writeFile(
-        path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION'),
-        '1.19.6\n',
-        'utf8'
-      )
-      await fs.writeFile(
-        path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'VERSION'),
-        '1.19.4\n',
-        'utf8'
-      )
+      await fs.writeFile(path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION'), '1.19.6\n', 'utf8')
+      await fs.writeFile(path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'VERSION'), '1.19.4\n', 'utf8')
 
       const resolverPath = path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'bin', 'update-target.cjs')
       const result = runNodeJson(
@@ -850,8 +512,8 @@ describe('multi-runtime validation', () => {
         ['--runtime', 'codex', '--cwd', projectDir, '--latest-version', '1.19.6'],
         {
           cwd: projectDir,
-          env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome }
-        }
+          env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+        },
       )
 
       expect(result.selected_target.scope).toBe('global')
@@ -881,25 +543,17 @@ describe('multi-runtime validation', () => {
           ...process.env,
           HOME: tmpdir,
           XDG_CONFIG_HOME: configHome,
-          CODEX_CONFIG_DIR: customCodexDir
+          CODEX_CONFIG_DIR: customCodexDir,
         },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
+        timeout: 30000,
       })
 
       const projectDir = path.join(tmpdir, 'project')
       await fs.mkdir(path.join(projectDir, '.codex', 'get-shit-done-reflect'), { recursive: true })
-      await fs.writeFile(
-        path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION'),
-        '1.19.3\n',
-        'utf8'
-      )
-      await fs.writeFile(
-        path.join(customCodexDir, 'get-shit-done-reflect', 'VERSION'),
-        '1.19.1\n',
-        'utf8'
-      )
+      await fs.writeFile(path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION'), '1.19.3\n', 'utf8')
+      await fs.writeFile(path.join(customCodexDir, 'get-shit-done-reflect', 'VERSION'), '1.19.1\n', 'utf8')
 
       const resolverPath = path.join(customCodexDir, 'get-shit-done-reflect', 'bin', 'update-target.cjs')
       const result = runNodeJson(
@@ -911,9 +565,9 @@ describe('multi-runtime validation', () => {
             ...process.env,
             HOME: tmpdir,
             XDG_CONFIG_HOME: configHome,
-            CODEX_CONFIG_DIR: customCodexDir
-          }
-        }
+            CODEX_CONFIG_DIR: customCodexDir,
+          },
+        },
       )
 
       expect(result.selected_target.scope).toBe('global')
@@ -940,13 +594,13 @@ describe('multi-runtime validation', () => {
         env: { ...process.env, HOME: homeDir, XDG_CONFIG_HOME: configHome },
         cwd: projectDir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
+        timeout: 30000,
       })
 
       await fs.writeFile(
         path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION'),
         '1.19.5\n',
-        'utf8'
+        'utf8',
       )
 
       const resolverPath = path.join(projectDir, '.codex', 'get-shit-done-reflect', 'bin', 'update-target.cjs')
@@ -955,15 +609,13 @@ describe('multi-runtime validation', () => {
         ['--runtime', 'codex', '--cwd', projectDir, '--latest-version', '1.19.6'],
         {
           cwd: projectDir,
-          env: { ...process.env, HOME: homeDir, XDG_CONFIG_HOME: configHome }
-        }
+          env: { ...process.env, HOME: homeDir, XDG_CONFIG_HOME: configHome },
+        },
       )
 
       expect(result.selected_target.scope).toBe('local')
       expect(result.install_args).toEqual(['--codex', '--local'])
-      expect(result.selected_target.version_path).toBe(
-        path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION')
-      )
+      expect(result.selected_target.version_path).toBe(path.join(projectDir, '.codex', 'get-shit-done-reflect', 'VERSION'))
 
       const skillPath = path.join(projectDir, '.codex', 'skills', 'gsdr-update', 'SKILL.md')
       const workflowPath = path.join(projectDir, '.codex', 'get-shit-done-reflect', 'workflows', 'update.md')
@@ -976,97 +628,55 @@ describe('multi-runtime validation', () => {
       expect(workflow).not.toContain('./.claude/')
     })
 
-    tmpdirTest('--all install: VERSION files present in all runtimes', async ({ tmpdir }) => {
+    tmpdirTest('--all install: VERSION files present in all supported runtimes', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // Collect VERSION file contents from all 4 runtimes
-      const versionPaths = [
-        path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'VERSION'),
-        path.join(configHome, 'opencode', 'get-shit-done-reflect', 'VERSION'),
-        path.join(tmpdir, '.gemini', 'get-shit-done-reflect', 'VERSION'),
-        path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'VERSION'),
-      ]
+      const versionPaths = SUPPORTED_INSTALLER_RUNTIMES.map((runtime) =>
+        path.join(getSupportedRuntimeBaseDir(tmpdir, runtime), 'get-shit-done-reflect', 'VERSION'),
+      )
 
       const versions = []
-      for (const vp of versionPaths) {
-        const exists = await fs.access(vp).then(() => true).catch(() => false)
-        expect(exists, `VERSION file should exist: ${vp}`).toBe(true)
-        const version = (await fs.readFile(vp, 'utf8')).trim()
+      for (const versionPath of versionPaths) {
+        await fileExists(versionPath)
+        const version = (await fs.readFile(versionPath, 'utf8')).trim()
         expect(version).toBeTruthy()
         versions.push(version)
       }
 
-      // All 4 runtimes should have the same version string
-      const [claude, opencode, gemini, codex] = versions
-      expect(opencode, 'OpenCode VERSION should match Claude').toBe(claude)
-      expect(gemini, 'Gemini VERSION should match Claude').toBe(claude)
-      expect(codex, 'Codex VERSION should match Claude').toBe(claude)
+      expect(new Set(versions).size, 'Supported runtimes should share a single VERSION value').toBe(1)
     })
   })
 
-  // ---------------------------------------------------------------------------
-  // Cross-runtime parity enforcement
-  // ---------------------------------------------------------------------------
-
-  describe('Cross-runtime parity enforcement', () => {
-    const SUPPORTED_RUNTIMES = ['claude', 'opencode', 'gemini', 'codex']
-
+  describe('Supported-runtime parity enforcement', () => {
     const INTENTIONAL_DIVERGENCES = {
       agentExtensions: {
-        claude: '.md', opencode: '.md', gemini: '.md', codex: '.toml',
-        // WHY: Codex uses TOML config files for agents, others use markdown
+        claude: '.md',
+        codex: '.toml',
       },
       commandStructure: {
         claude: { dir: 'commands/gsdr', nested: true },
-        opencode: { dir: 'command', nested: false },
-        gemini: { dir: 'commands/gsdr', nested: true },
         codex: { dir: 'skills', nested: false },
-        // WHY: Each runtime has its own command/skill format
       },
       hooksSupport: {
-        claude: true, opencode: false, gemini: true, codex: false,
-        // WHY: OpenCode has no settings.json hook system, Codex has no hook support
+        claude: true,
+        codex: false,
       },
       codexAgentsMd: true,
-      // WHY: Codex benefits from a consolidated AGENTS.md alongside individual .toml files
     }
 
-    tmpdirTest('artifact count parity across runtimes', async ({ tmpdir }) => {
+    tmpdirTest('artifact count parity across supported runtimes', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // Define paths for each runtime's artifact categories
       const runtimePaths = {
         claude: {
           agents: path.join(tmpdir, '.claude', 'agents'),
           workflows: path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'workflows'),
           references: path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'references'),
           templates: path.join(tmpdir, '.claude', 'get-shit-done-reflect', 'templates'),
-        },
-        opencode: {
-          agents: path.join(configHome, 'opencode', 'agents'),
-          workflows: path.join(configHome, 'opencode', 'get-shit-done-reflect', 'workflows'),
-          references: path.join(configHome, 'opencode', 'get-shit-done-reflect', 'references'),
-          templates: path.join(configHome, 'opencode', 'get-shit-done-reflect', 'templates'),
-        },
-        gemini: {
-          agents: path.join(tmpdir, '.gemini', 'agents'),
-          workflows: path.join(tmpdir, '.gemini', 'get-shit-done-reflect', 'workflows'),
-          references: path.join(tmpdir, '.gemini', 'get-shit-done-reflect', 'references'),
-          templates: path.join(tmpdir, '.gemini', 'get-shit-done-reflect', 'templates'),
         },
         codex: {
           agents: path.join(tmpdir, '.codex', 'agents'),
@@ -1076,151 +686,78 @@ describe('multi-runtime validation', () => {
         },
       }
 
-      // Count agents per runtime (using runtime-specific extensions)
       const agentCounts = {}
-      for (const runtime of SUPPORTED_RUNTIMES) {
+      for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
         const ext = INTENTIONAL_DIVERGENCES.agentExtensions[runtime]
         const dir = runtimePaths[runtime].agents
-        if (!fsSync.existsSync(dir)) {
-          agentCounts[runtime] = 0
-          continue
-        }
-        const entries = fsSync.readdirSync(dir)
-        agentCounts[runtime] = entries.filter(f => f.startsWith('gsdr-') && f.endsWith(ext)).length
+        const entries = fsSync.existsSync(dir) ? fsSync.readdirSync(dir) : []
+        agentCounts[runtime] = entries.filter((entry) => entry.startsWith('gsdr-') && entry.endsWith(ext)).length
       }
 
-      // All runtimes should have the same agent count
-      const refAgentCount = agentCounts.claude
-      expect(refAgentCount, 'Claude should have at least 1 agent').toBeGreaterThanOrEqual(1)
-      for (const runtime of SUPPORTED_RUNTIMES) {
-        expect(agentCounts[runtime], `Agent count parity: ${runtime} (${agentCounts[runtime]}) vs claude (${refAgentCount})`).toBe(refAgentCount)
+      const referenceAgentCount = agentCounts.claude
+      expect(referenceAgentCount, 'Claude should have at least 1 agent').toBeGreaterThanOrEqual(1)
+      for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
+        expect(agentCounts[runtime], `Agent count parity: ${runtime} (${agentCounts[runtime]}) vs claude (${referenceAgentCount})`).toBe(referenceAgentCount)
       }
 
-      // Count shared categories (workflows, references, templates) -- all use .md
       for (const category of ['workflows', 'references', 'templates']) {
         const counts = {}
-        for (const runtime of SUPPORTED_RUNTIMES) {
+        for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
           const dir = runtimePaths[runtime][category]
-          if (!fsSync.existsSync(dir)) {
-            counts[runtime] = 0
-            continue
-          }
-          const entries = fsSync.readdirSync(dir)
-          counts[runtime] = entries.filter(f => f.endsWith('.md')).length
+          const entries = fsSync.existsSync(dir) ? fsSync.readdirSync(dir) : []
+          counts[runtime] = entries.filter((entry) => entry.endsWith('.md')).length
         }
 
-        const refCount = counts.claude
-        expect(refCount, `Claude should have at least 1 ${category} file`).toBeGreaterThanOrEqual(1)
-        for (const runtime of SUPPORTED_RUNTIMES) {
-          expect(counts[runtime], `${category} count parity: ${runtime} (${counts[runtime]}) vs claude (${refCount})`).toBe(refCount)
+        const referenceCount = counts.claude
+        expect(referenceCount, `Claude should have at least 1 ${category} file`).toBeGreaterThanOrEqual(1)
+        for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
+          expect(counts[runtime], `${category} count parity: ${runtime} (${counts[runtime]}) vs claude (${referenceCount})`).toBe(referenceCount)
         }
       }
     })
 
-    tmpdirTest('agent name set equivalence across runtimes', async ({ tmpdir }) => {
+    tmpdirTest('agent name set equivalence across supported runtimes', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // Extract agent names per runtime, stripping runtime-specific extension
-      function getAgentNames(dir, ext) {
+      function getAgentNames(dir, extension) {
         if (!fsSync.existsSync(dir)) return []
-        const entries = fsSync.readdirSync(dir)
-        return entries
-          .filter(f => f.startsWith('gsdr-') && f.endsWith(ext))
-          .map(f => f.substring(0, f.lastIndexOf('.')))
+        return fsSync.readdirSync(dir)
+          .filter((entry) => entry.startsWith('gsdr-') && entry.endsWith(extension))
+          .map((entry) => entry.substring(0, entry.lastIndexOf('.')))
           .sort()
       }
 
-      const agentSets = {}
       const agentDirs = {
         claude: path.join(tmpdir, '.claude', 'agents'),
-        opencode: path.join(configHome, 'opencode', 'agents'),
-        gemini: path.join(tmpdir, '.gemini', 'agents'),
         codex: path.join(tmpdir, '.codex', 'agents'),
       }
 
-      for (const runtime of SUPPORTED_RUNTIMES) {
-        const ext = INTENTIONAL_DIVERGENCES.agentExtensions[runtime]
-        agentSets[runtime] = getAgentNames(agentDirs[runtime], ext)
+      const agentSets = {}
+      for (const runtime of SUPPORTED_INSTALLER_RUNTIMES) {
+        agentSets[runtime] = getAgentNames(agentDirs[runtime], INTENTIONAL_DIVERGENCES.agentExtensions[runtime])
       }
 
-      // All runtimes should have the identical sorted name list
       expect(agentSets.claude.length, 'should have at least 1 agent').toBeGreaterThanOrEqual(1)
-      expect(agentSets.opencode, 'Agent names: OpenCode vs Claude').toEqual(agentSets.claude)
-      expect(agentSets.gemini, 'Agent names: Gemini vs Claude').toEqual(agentSets.claude)
       expect(agentSets.codex, 'Agent names: Codex vs Claude').toEqual(agentSets.claude)
     })
 
-    tmpdirTest('content quality: runtime-specific transformations applied', async ({ tmpdir }) => {
+    tmpdirTest('content quality: supported-runtime transformations applied', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
-      })
+      await installAllSupported(tmpdir, configHome)
 
-      // 1. Gemini agents: no ${} template patterns in body
-      const geminiAgentsDir = path.join(tmpdir, '.gemini', 'agents')
-      const geminiAgentFiles = fsSync.readdirSync(geminiAgentsDir)
-        .filter(f => f.startsWith('gsdr-') && f.endsWith('.md'))
-      expect(geminiAgentFiles.length, 'should have Gemini agent files').toBeGreaterThanOrEqual(1)
-
-      for (const agentFile of geminiAgentFiles) {
-        const content = await fs.readFile(path.join(geminiAgentsDir, agentFile), 'utf8')
-        // Separate frontmatter from body (split on ---)
-        const parts = content.split('---')
-        const body = parts.slice(2).join('---')
-        // Strip fenced code blocks before checking -- bash ${ARRAY[@]} syntax
-        // inside code examples is intentional, not leaked template variables
-        const bodyWithoutCodeBlocks = body.replace(/```[\s\S]*?```/g, '')
-        const templateVarMatches = bodyWithoutCodeBlocks.match(/\$\{[^}]+\}/g)
-        expect(templateVarMatches, `Gemini ${agentFile}: body should have no \${} template variables outside code blocks (found: ${templateVarMatches})`).toBeNull()
-      }
-
-      // 2. Codex workflows: actual command invocations use $gsdr- not /gsdr:
-      // Note: /gsdr: may appear in prose documenting other runtimes' syntax.
-      // We check for actual command invocation patterns: /gsdr:verb-name
       const codexWorkflowsDir = path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'workflows')
-      const codexWorkflowFiles = fsSync.readdirSync(codexWorkflowsDir)
-        .filter(f => f.endsWith('.md'))
-
-      for (const wfFile of codexWorkflowFiles) {
-        const content = await fs.readFile(path.join(codexWorkflowsDir, wfFile), 'utf8')
-        // Check for /gsdr: used as actual command invocations (e.g., /gsdr:plan-phase, /gsdr:execute-phase)
-        // These are the patterns that should have been converted to $gsdr-plan-phase etc.
-        // Exclude prose/documentation references like "command prefix: /gsdr:" or lists of syntax formats
+      const codexWorkflowFiles = fsSync.readdirSync(codexWorkflowsDir).filter((entry) => entry.endsWith('.md'))
+      for (const workflowFile of codexWorkflowFiles) {
+        const content = await fs.readFile(path.join(codexWorkflowsDir, workflowFile), 'utf8')
         const commandInvocations = content.match(/\/gsdr:[a-z][\w-]*/g)
-        expect(commandInvocations, `Codex workflow ${wfFile}: should NOT contain /gsdr: command invocations (found: ${commandInvocations})`).toBeNull()
+        expect(commandInvocations, `Codex workflow ${workflowFile}: should NOT contain /gsdr: command invocations (found: ${commandInvocations})`).toBeNull()
       }
 
-      // 3. OpenCode agents: no skills: in frontmatter
-      const opcodeAgentsDir = path.join(configHome, 'opencode', 'agents')
-      const opcodeAgentFiles = fsSync.readdirSync(opcodeAgentsDir)
-        .filter(f => f.startsWith('gsdr-') && f.endsWith('.md'))
-      expect(opcodeAgentFiles.length, 'should have OpenCode agent files').toBeGreaterThanOrEqual(1)
-
-      for (const agentFile of opcodeAgentFiles) {
-        const content = await fs.readFile(path.join(opcodeAgentsDir, agentFile), 'utf8')
-        // Extract frontmatter (between first and second ---)
-        const parts = content.split('---')
-        if (parts.length >= 3) {
-          const frontmatter = parts[1]
-          expect(frontmatter, `OpenCode ${agentFile}: frontmatter should NOT contain skills:`).not.toContain('skills:')
-        }
-      }
-
-      // 4. Codex agent TOMLs: contain sandbox_mode =
       const codexAgentsDir = path.join(tmpdir, '.codex', 'agents')
-      const codexAgentFiles = fsSync.readdirSync(codexAgentsDir)
-        .filter(f => f.startsWith('gsdr-') && f.endsWith('.toml'))
+      const codexAgentFiles = fsSync.readdirSync(codexAgentsDir).filter((entry) => entry.startsWith('gsdr-') && entry.endsWith('.toml'))
       expect(codexAgentFiles.length, 'should have Codex agent TOML files').toBeGreaterThanOrEqual(1)
 
       for (const agentFile of codexAgentFiles) {
@@ -1229,55 +766,43 @@ describe('multi-runtime validation', () => {
       }
     })
 
-    tmpdirTest('new runtime detection: unknown runtime directories flagged', async ({ tmpdir }) => {
+    tmpdirTest('new runtime detection: unexpected runtime directories flagged against runtime-support authority', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --all --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 30000
+      await installAllSupported(tmpdir, configHome)
+
+      const knownHiddenDirs = new Set([
+        ...SUPPORTED_INSTALLER_RUNTIMES.map((runtime) => INSTALLER_RUNTIME_METADATA[runtime].dirName),
+        '.config',
+        '.gsd',
+        '.npm',
+        '.node_modules',
+      ])
+      const entries = fsSync.readdirSync(tmpdir, { withFileTypes: true })
+      const hiddenDirs = entries.filter((entry) => entry.isDirectory() && entry.name.startsWith('.')).map((entry) => entry.name)
+
+      const suspiciousRuntimeDirs = hiddenDirs.filter((dir) => {
+        if (knownHiddenDirs.has(dir)) return false
+        const dirPath = path.join(tmpdir, dir)
+        return (
+          dir === '.gemini' ||
+          dir === '.opencode' ||
+          fsSync.existsSync(path.join(dirPath, 'agents')) ||
+          fsSync.existsSync(path.join(dirPath, 'get-shit-done-reflect'))
+        )
       })
 
-      // Known directories that are expected after --all install
-      const knownDirs = new Set([
-        '.claude', '.codex', '.gemini', '.config', '.gsd',
-        '.npm', '.node_modules',
-      ])
-
-      // Plausible future runtime directories to watch for
-      const futureRuntimePatterns = ['.copilot', '.cursor', '.windsurf', '.agent', '.aide']
-
-      // Scan tmpdir for hidden directories
-      const entries = fsSync.readdirSync(tmpdir, { withFileTypes: true })
-      const hiddenDirs = entries
-        .filter(e => e.isDirectory() && e.name.startsWith('.'))
-        .map(e => e.name)
-
-      // Flag any hidden directory that matches a future runtime pattern
-      const unexpectedRuntimes = hiddenDirs.filter(
-        dir => futureRuntimePatterns.includes(dir) && !knownDirs.has(dir)
-      )
-
       expect(
-        unexpectedRuntimes,
-        `Detected runtime directory ${unexpectedRuntimes.join(', ')} not in SUPPORTED_RUNTIMES -- add parity coverage`
+        suspiciousRuntimeDirs,
+        `Detected runtime directory ${suspiciousRuntimeDirs.join(', ')} outside SUPPORTED_INSTALLER_RUNTIMES in get-shit-done/bin/lib/runtime-support.cjs`,
       ).toHaveLength(0)
 
-      // Also flag any completely unknown hidden directory not in knownDirs
-      // (catches installer producing unexpected output)
-      const unknownDirs = hiddenDirs.filter(dir => !knownDirs.has(dir))
-      // Only warn about unknown dirs that look like they could be runtimes
-      // (have agents/ or get-shit-done-reflect/ subdir)
-      const suspiciousUnknown = unknownDirs.filter(dir => {
-        const dirPath = path.join(tmpdir, dir)
-        return fsSync.existsSync(path.join(dirPath, 'agents')) ||
-               fsSync.existsSync(path.join(dirPath, 'get-shit-done-reflect'))
-      })
-
+      const unexpectedConfigDirs = fsSync.existsSync(configHome)
+        ? fsSync.readdirSync(configHome, { withFileTypes: true }).filter((entry) => entry.isDirectory() && entry.name === 'opencode').map((entry) => entry.name)
+        : []
       expect(
-        suspiciousUnknown,
-        `Unknown directories with runtime-like structure: ${suspiciousUnknown.join(', ')} -- investigate and add to SUPPORTED_RUNTIMES or knownDirs`
+        unexpectedConfigDirs,
+        `Detected config runtime directory ${unexpectedConfigDirs.join(', ')} outside SUPPORTED_INSTALLER_RUNTIMES in get-shit-done/bin/lib/runtime-support.cjs`,
       ).toHaveLength(0)
     })
   })

--- a/tests/unit/install.test.js
+++ b/tests/unit/install.test.js
@@ -10,8 +10,9 @@ import os from 'node:os'
 // Import functions for direct unit testing
 import { createRequire } from 'node:module'
 const require = createRequire(import.meta.url)
-const { replacePathsInContent, injectVersionScope, getGsdHome, migrateKB, countKBEntries, createProjectLocalKB, convertClaudeToCodexSkill, convertClaudeToCodexMarkdown, convertClaudeToCodexAgentToml, copyCodexSkills, generateCodexAgentsMd, generateCodexMcpConfig, generateCodexConfigBlock, stripGsdFromCodexConfig, mergeCodexConfig, CODEX_AGENT_SANDBOX, GSD_CODEX_MARKER, convertClaudeToGeminiAgent, safeFs, extractFrontmatterAndBody, extractFrontmatterField, convertClaudeToOpencodeFrontmatter, resolveOpencodeConfigPath, readSettings, writeSettings, copyWithPathReplacement, generateMigrationGuide, isVersionInRange, compareVersions, cleanupOrphanedFiles, validateHookFields } = require('../../bin/install.js')
+const { replacePathsInContent, injectVersionScope, getGsdHome, migrateKB, countKBEntries, createProjectLocalKB, convertClaudeToCodexSkill, convertClaudeToCodexMarkdown, convertClaudeToCodexAgentToml, copyCodexSkills, generateCodexAgentsMd, generateCodexMcpConfig, generateCodexConfigBlock, stripGsdFromCodexConfig, mergeCodexConfig, CODEX_AGENT_SANDBOX, GSD_CODEX_MARKER, safeFs, extractFrontmatterAndBody, extractFrontmatterField, readSettings, writeSettings, copyWithPathReplacement, generateMigrationGuide, isVersionInRange, compareVersions, cleanupOrphanedFiles, validateHookFields } = require('../../bin/install.js')
 const { resolveCodexUpdateTarget, CODEX_CACHE_DOES_NOT_APPLY_REASON } = require('../../get-shit-done/bin/lib/update-target.cjs')
+const { SUPPORTED_INSTALLER_RUNTIMES, expandInstallerRuntimeSelection } = require('../../get-shit-done/bin/lib/runtime-support.cjs')
 
 function buildReadFileSync(fileMap) {
   return vi.fn((filePath) => {
@@ -30,6 +31,11 @@ function buildReadFileSync(fileMap) {
 describe('install script', () => {
   describe('merged installer flags', () => {
     const installScript = path.resolve(process.cwd(), 'bin/install.js')
+
+    it('uses the shared runtime-support helper as the --all authority', () => {
+      expect(expandInstallerRuntimeSelection({ all: true })).toEqual(SUPPORTED_INSTALLER_RUNTIMES)
+      expect(SUPPORTED_INSTALLER_RUNTIMES).toEqual(['claude', 'codex'])
+    })
 
     tmpdirTest('--claude flag installs to .claude directory', async ({ tmpdir }) => {
       execSync(`node "${installScript}" --claude --global`, {
@@ -59,51 +65,50 @@ describe('install script', () => {
       expect(version).toBeTruthy()
     })
 
-    tmpdirTest('--opencode flag installs to opencode config directory', async ({ tmpdir }) => {
+    tmpdirTest('--all --global installs only Claude Code and Codex CLI', async ({ tmpdir }) => {
       const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --opencode --global`, {
+      execSync(`node "${installScript}" --all --global`, {
         env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
         cwd: tmpdir,
         stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        timeout: 30000
       })
 
-      // Verify opencode command directory with flattened gsdr-*.md files
-      const commandDir = path.join(configHome, 'opencode', 'command')
-      const commandExist = await fs.access(commandDir).then(() => true).catch(() => false)
-      expect(commandExist).toBe(true)
+      const claudeDir = path.join(tmpdir, '.claude', 'commands', 'gsdr')
+      const codexDir = path.join(tmpdir, '.codex', 'skills')
+      expect(await fs.access(claudeDir).then(() => true).catch(() => false)).toBe(true)
+      expect(await fs.access(codexDir).then(() => true).catch(() => false)).toBe(true)
 
-      const commandFiles = await fs.readdir(commandDir)
-      const gsdFiles = commandFiles.filter(f => f.startsWith('gsdr-') && f.endsWith('.md'))
-      expect(gsdFiles.length).toBeGreaterThan(0)
-
-      // Verify get-shit-done-reflect directory exists
-      const gsdDir = path.join(configHome, 'opencode', 'get-shit-done-reflect')
-      const gsdExist = await fs.access(gsdDir).then(() => true).catch(() => false)
-      expect(gsdExist).toBe(true)
+      expect(await fs.access(path.join(tmpdir, '.gemini')).then(() => true).catch(() => false)).toBe(false)
+      expect(await fs.access(path.join(configHome, 'opencode')).then(() => true).catch(() => false)).toBe(false)
     })
 
-    tmpdirTest('--claude --opencode installs to both directories', async ({ tmpdir }) => {
-      const configHome = path.join(tmpdir, '.config')
+    for (const flag of ['--gemini', '--opencode', '--both']) {
+      tmpdirTest(`${flag} exits non-zero with unsupported-runtime guidance`, async ({ tmpdir }) => {
+        const configHome = path.join(tmpdir, '.config')
 
-      execSync(`node "${installScript}" --claude --opencode --global`, {
-        env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
-        cwd: tmpdir,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        timeout: 15000
+        let error
+        try {
+          execSync(`node "${installScript}" ${flag} --global`, {
+            env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+            cwd: tmpdir,
+            stdio: ['pipe', 'pipe', 'pipe'],
+            timeout: 15000
+          })
+        } catch (caught) {
+          error = caught
+        }
+
+        expect(error).toBeTruthy()
+        expect(error.status).not.toBe(0)
+        const output = `${error.stdout?.toString() || ''}${error.stderr?.toString() || ''}`
+        expect(output).toMatch(/unsupported installer target/i)
+        expect(output).toMatch(/--claude, --codex, or --all/i)
+        expect(await fs.access(path.join(tmpdir, '.gemini')).then(() => true).catch(() => false)).toBe(false)
+        expect(await fs.access(path.join(configHome, 'opencode')).then(() => true).catch(() => false)).toBe(false)
       })
-
-      // Verify Claude directory populated
-      const claudeCommandsDir = path.join(tmpdir, '.claude', 'commands', 'gsdr')
-      const claudeExist = await fs.access(claudeCommandsDir).then(() => true).catch(() => false)
-      expect(claudeExist).toBe(true)
-
-      // Verify OpenCode directory populated
-      const opcodeCommandDir = path.join(configHome, 'opencode', 'command')
-      const opcodeExist = await fs.access(opcodeCommandDir).then(() => true).catch(() => false)
-      expect(opcodeExist).toBe(true)
-    })
+    }
 
     tmpdirTest('no flags with non-TTY stdin defaults to claude global install', async ({ tmpdir }) => {
       // When stdin is not a TTY (subprocess with piped stdio),
@@ -819,110 +824,6 @@ describe('install script', () => {
       })
     })
 
-    describe('convertClaudeToOpencodeFrontmatter', () => {
-      describe('isAgent parameter', () => {
-        it('strips skills field with array items when isAgent is true', () => {
-          const input = '---\ndescription: test\nskills:\n  - skill1\n  - skill2\ncolor: blue\n---\nbody'
-          const result = convertClaudeToOpencodeFrontmatter(input, { isAgent: true })
-          expect(result).not.toContain('skills:')
-          expect(result).not.toContain('skill1')
-          expect(result).not.toContain('color:')
-          expect(result).toContain('description: test')
-        })
-
-        it('strips memory, maxTurns, permissionMode, disallowedTools when isAgent is true', () => {
-          const input = '---\ndescription: test\nmemory: true\nmaxTurns: 5\npermissionMode: auto\ndisallowedTools:\n  - Write\n  - Edit\n---\nbody'
-          const result = convertClaudeToOpencodeFrontmatter(input, { isAgent: true })
-          expect(result).not.toContain('memory:')
-          expect(result).not.toContain('maxTurns:')
-          expect(result).not.toContain('permissionMode:')
-          expect(result).not.toContain('disallowedTools:')
-          expect(result).not.toContain('Write')
-          expect(result).toContain('description: test')
-        })
-
-        it('skips commented lines when isAgent is true', () => {
-          const input = '---\ndescription: test\n# hooks:\n#   pre-tool-use: check.sh\n---\nbody'
-          const result = convertClaudeToOpencodeFrontmatter(input, { isAgent: true })
-          expect(result).not.toContain('hooks:')
-          expect(result).not.toContain('check.sh')
-          expect(result).toContain('description: test')
-        })
-
-        it('preserves color field when isAgent is false (default)', () => {
-          const input = '---\ncolor: blue\ndescription: test\n---\nbody'
-          const result = convertClaudeToOpencodeFrontmatter(input)
-          // color: blue gets converted to hex by the color converter
-          expect(result).toContain('color:')
-          expect(result).toContain('description: test')
-        })
-
-        it('preserves color field when isAgent is explicitly false', () => {
-          const input = '---\ncolor: blue\ndescription: test\n---\nbody'
-          const result = convertClaudeToOpencodeFrontmatter(input, { isAgent: false })
-          expect(result).toContain('color:')
-        })
-      })
-
-      describe('subagent_type remapping', () => {
-        it('remaps subagent_type="general-purpose" to "general"', () => {
-          const input = '---\ndescription: test\n---\nUse subagent_type="general-purpose" for tasks'
-          const result = convertClaudeToOpencodeFrontmatter(input)
-          expect(result).toContain('subagent_type="general"')
-          expect(result).not.toContain('general-purpose')
-        })
-
-        it('does not remap other subagent_type values', () => {
-          const input = '---\ndescription: test\n---\nUse subagent_type="specialist" here'
-          const result = convertClaudeToOpencodeFrontmatter(input)
-          expect(result).toContain('subagent_type="specialist"')
-        })
-      })
-
-      describe('existing behavior preserved', () => {
-        it('replaces tool names (AskUserQuestion, SlashCommand, TodoWrite)', () => {
-          const input = '---\ndescription: test\n---\nUse AskUserQuestion and SlashCommand and TodoWrite'
-          const result = convertClaudeToOpencodeFrontmatter(input)
-          expect(result).toContain('question')
-          expect(result).toContain('skill')
-          expect(result).toContain('todowrite')
-          expect(result).not.toContain('AskUserQuestion')
-        })
-
-        it('converts allowed-tools to tools object', () => {
-          const input = '---\nallowed-tools:\n  - Read\n  - Write\n---\nbody'
-          const result = convertClaudeToOpencodeFrontmatter(input)
-          expect(result).toContain('tools:')
-          expect(result).toContain('read: true')
-          expect(result).toContain('write: true')
-        })
-      })
-    })
-
-    describe('resolveOpencodeConfigPath', () => {
-      it('prefers .jsonc when it exists', () => {
-        const tmpDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'gsd-test-'))
-        try {
-          fsSync.writeFileSync(path.join(tmpDir, 'opencode.json'), '{}')
-          fsSync.writeFileSync(path.join(tmpDir, 'opencode.jsonc'), '{}')
-          const result = resolveOpencodeConfigPath(tmpDir)
-          expect(result).toBe(path.join(tmpDir, 'opencode.jsonc'))
-        } finally {
-          fsSync.rmSync(tmpDir, { recursive: true })
-        }
-      })
-
-      it('falls back to .json when .jsonc does not exist', () => {
-        const tmpDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'gsd-test-'))
-        try {
-          const result = resolveOpencodeConfigPath(tmpDir)
-          expect(result).toBe(path.join(tmpDir, 'opencode.json'))
-        } finally {
-          fsSync.rmSync(tmpDir, { recursive: true })
-        }
-      })
-    })
-
     describe('readSettings and writeSettings', () => {
       it('readSettings returns empty object for missing file', () => {
         const result = readSettings('/nonexistent/path/settings.json')
@@ -1015,65 +916,47 @@ describe('install script', () => {
     describe('integration: full installer', () => {
       const installScript = path.resolve(process.cwd(), 'bin/install.js')
 
-      tmpdirTest('OpenCode install preserves already-migrated KB paths', async ({ tmpdir }) => {
-        const configHome = path.join(tmpdir, '.config')
-
-        execSync(`node "${installScript}" --opencode --global`, {
-          env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+      tmpdirTest('Codex install preserves already-migrated KB paths', async ({ tmpdir }) => {
+        execSync(`node "${installScript}" --codex --global`, {
+          env: { ...process.env, HOME: tmpdir },
           cwd: tmpdir,
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 15000
         })
 
-        // Read reflect.md which contains KB paths (already ~/.gsd/knowledge/ in source)
-        const reflectWorkflow = path.join(configHome, 'opencode', 'get-shit-done-reflect', 'workflows', 'reflect.md')
+        const reflectWorkflow = path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'workflows', 'reflect.md')
         const content = await fs.readFile(reflectWorkflow, 'utf8')
 
-        // KB paths should remain at shared location (no-op for Pass 1)
         expect(content).toContain('~/.gsd/knowledge')
-        // KB paths must NOT be transformed to OpenCode-specific paths
-        expect(content).not.toContain('~/.config/opencode/gsd-knowledge')
-        // Legacy KB paths should not appear
         expect(content).not.toContain('~/.claude/gsd-knowledge')
       })
 
-      tmpdirTest('OpenCode install preserves already-migrated $HOME KB paths', async ({ tmpdir }) => {
-        const configHome = path.join(tmpdir, '.config')
-
-        execSync(`node "${installScript}" --opencode --global`, {
-          env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+      tmpdirTest('Codex install preserves already-migrated $HOME KB paths', async ({ tmpdir }) => {
+        execSync(`node "${installScript}" --codex --global`, {
+          env: { ...process.env, HOME: tmpdir },
           cwd: tmpdir,
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 15000
         })
 
-        // Read reflect.md which has $HOME/.gsd/knowledge (already migrated in source)
-        const reflectWorkflow = path.join(configHome, 'opencode', 'get-shit-done-reflect', 'workflows', 'reflect.md')
+        const reflectWorkflow = path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'workflows', 'reflect.md')
         const content = await fs.readFile(reflectWorkflow, 'utf8')
 
-        // $HOME/.gsd/knowledge should pass through unchanged
         expect(content).toContain('$HOME/.gsd/knowledge')
-        // Must NOT be transformed to OpenCode-specific path
-        expect(content).not.toContain('$HOME/.config/opencode/gsd-knowledge')
-        // Legacy path should not appear
         expect(content).not.toContain('$HOME/.claude/gsd-knowledge')
       })
 
-      tmpdirTest('OpenCode install transforms runtime-specific $HOME paths', async ({ tmpdir }) => {
-        const configHome = path.join(tmpdir, '.config')
-
-        execSync(`node "${installScript}" --opencode --global`, {
-          env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+      tmpdirTest('Codex install preserves shared KB paths in probe docs', async ({ tmpdir }) => {
+        execSync(`node "${installScript}" --codex --global`, {
+          env: { ...process.env, HOME: tmpdir },
           cwd: tmpdir,
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 15000
         })
 
-        // Read kb-integrity.md probe which has $HOME/.gsd/knowledge (shared KB path)
-        const kbProbe = path.join(configHome, 'opencode', 'get-shit-done-reflect', 'references', 'health-probes', 'kb-integrity.md')
+        const kbProbe = path.join(tmpdir, '.codex', 'get-shit-done-reflect', 'references', 'health-probes', 'kb-integrity.md')
         const content = await fs.readFile(kbProbe, 'utf8')
 
-        // KB paths already at shared location should pass through unchanged
         expect(content).toContain('$HOME/.gsd/knowledge')
       })
 
@@ -1214,7 +1097,7 @@ describe('install script', () => {
       tmpdirTest('does not create symlink when Claude not in runtimes (fresh install)', async ({ tmpdir }) => {
         withMockHome(tmpdir, () => {
           const gsdHome = path.join(tmpdir, '.gsd')
-          migrateKB(gsdHome, ['opencode'])
+          migrateKB(gsdHome, ['codex'])
 
           const oldKBDir = path.join(tmpdir, '.claude', 'gsd-knowledge')
           expect(fsSync.existsSync(oldKBDir)).toBe(false)
@@ -1326,7 +1209,7 @@ describe('install script', () => {
       tmpdirTest('symlink NOT created when only non-Claude runtimes selected', async ({ tmpdir }) => {
         withMockHome(tmpdir, () => {
           const gsdHome = path.join(tmpdir, '.gsd')
-          migrateKB(gsdHome, ['opencode', 'gemini'])
+          migrateKB(gsdHome, ['codex'])
 
           const oldKBDir = path.join(tmpdir, '.claude', 'gsd-knowledge')
           // Should not exist at all since no Claude runtime selected
@@ -1391,11 +1274,9 @@ describe('install script', () => {
         expect(stat.isSymbolicLink()).toBe(true)
       })
 
-      tmpdirTest('OpenCode-only install creates KB dirs but no symlink at ~/.claude/', async ({ tmpdir }) => {
-        const configHome = path.join(tmpdir, '.config')
-
-        execSync(`node "${installScript}" --opencode --global`, {
-          env: { ...process.env, HOME: tmpdir, XDG_CONFIG_HOME: configHome },
+      tmpdirTest('Codex-only install creates KB dirs but no symlink at ~/.claude/', async ({ tmpdir }) => {
+        execSync(`node "${installScript}" --codex --global`, {
+          env: { ...process.env, HOME: tmpdir },
           cwd: tmpdir,
           stdio: ['pipe', 'pipe', 'pipe'],
           timeout: 15000
@@ -1406,7 +1287,7 @@ describe('install script', () => {
         const signalsExist = await fs.access(path.join(kbDir, 'signals')).then(() => true).catch(() => false)
         expect(signalsExist).toBe(true)
 
-        // Verify NO symlink at ~/.claude/gsd-knowledge (only OpenCode selected)
+        // Verify NO symlink at ~/.claude/gsd-knowledge (only Codex selected)
         const oldKBDir = path.join(tmpdir, '.claude', 'gsd-knowledge')
         const exists = await fs.access(oldKBDir).then(() => true).catch(() => false)
         expect(exists).toBe(false)
@@ -1922,7 +1803,7 @@ Agent body content`
         }
       })
 
-      tmpdirTest('--all --global installs Codex alongside other runtimes', async ({ tmpdir }) => {
+      tmpdirTest('--all --global installs only supported runtimes', async ({ tmpdir }) => {
         const configHome = path.join(tmpdir, '.config')
 
         execSync(`node "${installScript}" --all --global`, {
@@ -1946,15 +1827,14 @@ Agent body content`
         const claudeExists = await fs.access(claudeDir).then(() => true).catch(() => false)
         expect(claudeExists).toBe(true)
 
-        // Verify OpenCode installed
-        const opcodeDir = path.join(configHome, 'opencode', 'command')
+        // Verify unsupported legacy runtimes are not installed
+        const opcodeDir = path.join(configHome, 'opencode')
         const opcodeExists = await fs.access(opcodeDir).then(() => true).catch(() => false)
-        expect(opcodeExists).toBe(true)
+        expect(opcodeExists).toBe(false)
 
-        // Verify Gemini installed
-        const geminiDir = path.join(tmpdir, '.gemini', 'commands', 'gsdr')
+        const geminiDir = path.join(tmpdir, '.gemini')
         const geminiExists = await fs.access(geminiDir).then(() => true).catch(() => false)
-        expect(geminiExists).toBe(true)
+        expect(geminiExists).toBe(false)
       })
 
       tmpdirTest('Codex path replacement converts ~/.claude/ to ~/.codex/ in installed files', async ({ tmpdir }) => {
@@ -2010,34 +1890,6 @@ Agent body content`
       expect(output).not.toContain('$ARGUMENTS')
     })
 
-    tmpdirTest('Gemini with isCommand=true produces .toml file', async ({ tmpdir }) => {
-      const srcDir = path.join(tmpdir, 'src')
-      const destDir = path.join(tmpdir, 'dest')
-      fsSync.mkdirSync(srcDir, { recursive: true })
-      fsSync.writeFileSync(path.join(srcDir, 'help.md'), '---\ndescription: Help command\n---\nHelp body')
-
-      copyWithPathReplacement(srcDir, destDir, '~/.gemini/', 'gemini', true, false)
-
-      // .toml file should exist
-      expect(fsSync.existsSync(path.join(destDir, 'help.toml'))).toBe(true)
-      // .md file should NOT exist (TOML replaces it)
-      expect(fsSync.existsSync(path.join(destDir, 'help.md'))).toBe(false)
-    })
-
-    tmpdirTest('Gemini with isCommand=false keeps .md file (no TOML)', async ({ tmpdir }) => {
-      const srcDir = path.join(tmpdir, 'src')
-      const destDir = path.join(tmpdir, 'dest')
-      fsSync.mkdirSync(srcDir, { recursive: true })
-      fsSync.writeFileSync(path.join(srcDir, 'workflow.md'), '# Workflow\n\nSome workflow content')
-
-      copyWithPathReplacement(srcDir, destDir, '~/.gemini/', 'gemini', false, false)
-
-      // .md file should exist
-      expect(fsSync.existsSync(path.join(destDir, 'workflow.md'))).toBe(true)
-      // .toml file should NOT exist
-      expect(fsSync.existsSync(path.join(destDir, 'workflow.toml'))).toBe(false)
-    })
-
     tmpdirTest('Claude runtime writes .md as-is (no conversion of command syntax)', async ({ tmpdir }) => {
       const srcDir = path.join(tmpdir, 'src')
       const destDir = path.join(tmpdir, 'dest')
@@ -2050,21 +1902,6 @@ Agent body content`
       // Claude does NOT convert command syntax — /gsdr: should remain
       expect(output).toContain('/gsdr:test')
       expect(output).not.toContain('$gsdr')
-    })
-
-    tmpdirTest('OpenCode runtime applies frontmatter conversion', async ({ tmpdir }) => {
-      const srcDir = path.join(tmpdir, 'src')
-      const destDir = path.join(tmpdir, 'dest')
-      fsSync.mkdirSync(srcDir, { recursive: true })
-      fsSync.writeFileSync(path.join(srcDir, 'test.md'), '---\nname: test\ndescription: A test\nallowed-tools:\n  - Read\n  - Bash\n---\n\nBody content')
-
-      copyWithPathReplacement(srcDir, destDir, '~/.opencode/', 'opencode', false, false)
-
-      const output = fsSync.readFileSync(path.join(destDir, 'test.md'), 'utf8')
-      // OpenCode converts frontmatter: allowed-tools becomes tools
-      expect(output).toContain('tools:')
-      // Body should be present
-      expect(output).toContain('Body content')
     })
 
     tmpdirTest('recursive directory traversal propagates isCommand and isGlobal', async ({ tmpdir }) => {
@@ -2092,284 +1929,6 @@ Agent body content`
       const output = fsSync.readFileSync(path.join(destDir, 'data.json'), 'utf8')
       // JSON file should be copied as-is (no conversion)
       expect(output).toContain('/gsdr:test')
-    })
-  })
-
-  describe('Gemini CLI MCP tool preservation', () => {
-    describe('convertClaudeToGeminiAgent() unit tests', () => {
-      it('preserves MCP tools in Gemini agent tools field', () => {
-        const input = `---
-tools: Read, Write, Bash, mcp__context7__resolve-library-id
----
-
-Agent body content.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        // MCP tool should be preserved as-is
-        expect(result).toContain('mcp__context7__resolve-library-id')
-        // Built-in tool should be converted to Gemini name
-        expect(result).toContain('read_file')
-        // Original Claude tool name should be converted
-        expect(result).not.toMatch(/\bRead\b/)
-      })
-
-      it('preserves MCP tools from allowed-tools YAML array in Gemini agent', () => {
-        const input = `---
-allowed-tools:
-  - Read
-  - Write
-  - Task
-  - mcp__context7__*
----
-
-Agent body content.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        // MCP tool wildcard should be preserved
-        expect(result).toContain('mcp__context7__*')
-        // Task should be excluded (agents auto-register in Gemini)
-        expect(result).not.toMatch(/\bTask\b/)
-        // Built-in tool should be converted
-        expect(result).toContain('read_file')
-      })
-
-      it('preserves multiple MCP tools in Gemini agent', () => {
-        const input = `---
-tools: Read, mcp__context7__resolve-library-id, mcp__context7__query-docs, mcp__fetch__get
----
-
-Agent body content.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        expect(result).toContain('mcp__context7__resolve-library-id')
-        expect(result).toContain('mcp__context7__query-docs')
-        expect(result).toContain('mcp__fetch__get')
-      })
-    })
-
-    describe('Gemini agent template escaping and field stripping', () => {
-      it('escapes ${VAR} patterns to $VAR in body text', () => {
-        const input = `---
-tools: Read
----
-
-Use \${PHASE} and \${PLAN} and \${DESCRIPTION} variables.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        expect(result).toContain('$PHASE')
-        expect(result).toContain('$PLAN')
-        expect(result).toContain('$DESCRIPTION')
-        expect(result).not.toContain('${PHASE}')
-        expect(result).not.toContain('${PLAN}')
-      })
-
-      it('preserves non-matching dollar patterns ($SIMPLE, $(command))', () => {
-        const input = `---
-tools: Read
----
-
-Use $SIMPLE and $(command) substitution.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        expect(result).toContain('$SIMPLE')
-        expect(result).toContain('$(command)')
-      })
-
-      it('applies template escaping after tool name replacement', () => {
-        const input = `---
-tools: Read
----
-
-Use the Read tool with \${PHASE} variable.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        // Tool name replacement happened
-        expect(result).toContain('read_file tool')
-        expect(result).not.toMatch(/\bRead\b/)
-        // Template escaping also happened
-        expect(result).toContain('$PHASE')
-        expect(result).not.toContain('${PHASE}')
-      })
-
-      it('strips skills: field with inline value', () => {
-        const input = `---
-tools: Read
-skills: planning, research
-description: test agent
----
-
-Agent body.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        expect(result).not.toContain('skills:')
-        expect(result).not.toContain('planning')
-        expect(result).not.toContain('research')
-        expect(result).toContain('description: test agent')
-      })
-
-      it('strips skills: field with YAML array items', () => {
-        const input = `---
-tools: Read
-skills:
-  - planning
-  - research
-description: test agent
----
-
-Agent body.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        expect(result).not.toContain('skills:')
-        expect(result).not.toContain('planning')
-        expect(result).not.toContain('research')
-        expect(result).toContain('description: test agent')
-      })
-
-      it('strips both skills: and color: fields when both present', () => {
-        const input = `---
-tools: Read
-color: blue
-skills: planning
-description: test agent
----
-
-Agent body.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        expect(result).not.toContain('color:')
-        expect(result).not.toContain('blue')
-        expect(result).not.toContain('skills:')
-        expect(result).not.toContain('planning')
-        expect(result).toContain('description: test agent')
-        expect(result).toContain('tools:')
-      })
-
-      it('regression: existing color and tools conversion unchanged', () => {
-        const input = `---
-tools: Read, Write
-color: red
-description: test agent
----
-
-Use Read to read files.`
-
-        const result = convertClaudeToGeminiAgent(input)
-
-        // color stripped
-        expect(result).not.toContain('color:')
-        // tools converted to YAML array with Gemini names
-        expect(result).toContain('tools:')
-        expect(result).toContain('  - read_file')
-        expect(result).toContain('  - write_file')
-        // body text uses Gemini tool names
-        expect(result).toContain('read_file to read files')
-        expect(result).not.toMatch(/\bRead\b/)
-      })
-    })
-  })
-
-  describe('Gemini agent body text tool name replacement', () => {
-    it('replaces Claude tool names with Gemini names in body text', () => {
-      const input = `---
-tools: Read, Write, Bash
----
-
-Use the Read tool to read files.
-Use Write to create new files.
-Run Bash to execute commands.
-Use Grep for searching and Glob for finding files.`
-
-      const result = convertClaudeToGeminiAgent(input)
-
-      // Body text should use Gemini tool names
-      expect(result).toContain('read_file tool to read files')
-      expect(result).toContain('Use write_file to create')
-      expect(result).toContain('Run run_shell_command to execute')
-      expect(result).toContain('Use search_file_content for searching')
-      expect(result).toContain('glob for finding files')
-      // Claude tool names should not remain in body
-      expect(result).not.toMatch(/\bRead\b/)
-      expect(result).not.toMatch(/\bWrite\b/)
-      expect(result).not.toMatch(/\bBash\b/)
-    })
-
-    it('preserves MCP tool references in body text while replacing Claude names', () => {
-      const input = `---
-tools: Read
----
-
-Use mcp__context7__resolve-library-id to find libraries.
-Also use the Read tool to read files.`
-
-      const result = convertClaudeToGeminiAgent(input)
-
-      // MCP reference should be unchanged
-      expect(result).toContain('mcp__context7__resolve-library-id')
-      // Claude tool name should be replaced
-      expect(result).toContain('read_file tool')
-      expect(result).not.toMatch(/\bRead\b/)
-    })
-
-    it('replaces all mapped tools in body text', () => {
-      const input = `---
-tools: Read, Write, Edit, Bash, Glob, Grep
----
-
-Read files. Write files. Edit content. Bash commands.
-Glob patterns. Grep search. WebSearch queries. WebFetch pages.
-TodoWrite tasks. AskUserQuestion prompts.`
-
-      const result = convertClaudeToGeminiAgent(input)
-
-      expect(result).toContain('read_file')
-      expect(result).toContain('write_file')
-      expect(result).toContain('replace')
-      expect(result).toContain('run_shell_command')
-      expect(result).toContain('glob')
-      expect(result).toContain('search_file_content')
-      expect(result).toContain('google_web_search')
-      expect(result).toContain('web_fetch')
-      expect(result).toContain('write_todos')
-      expect(result).toContain('ask_user')
-      // No Claude tool names should remain
-      expect(result).not.toMatch(/\bRead\b/)
-      expect(result).not.toMatch(/\bWrite\b/)
-      expect(result).not.toMatch(/\bEdit\b/)
-      expect(result).not.toMatch(/\bBash\b/)
-      expect(result).not.toMatch(/\bGrep\b/)
-      expect(result).not.toMatch(/\bWebSearch\b/)
-      expect(result).not.toMatch(/\bWebFetch\b/)
-      expect(result).not.toMatch(/\bTodoWrite\b/)
-      expect(result).not.toMatch(/\bAskUserQuestion\b/)
-    })
-
-    it('converts both frontmatter and body text tool names', () => {
-      const input = `---
-tools: Read, Write, Bash
----
-
-Use Read to read files. Run Bash for commands. Use Write to create files.`
-
-      const result = convertClaudeToGeminiAgent(input)
-
-      // Frontmatter should have Gemini tool names as YAML array
-      expect(result).toContain('tools:')
-      expect(result).toContain('  - read_file')
-      expect(result).toContain('  - write_file')
-      expect(result).toContain('  - run_shell_command')
-      // Body should also have Gemini tool names
-      expect(result).toContain('Use read_file to read files')
-      expect(result).toContain('Run run_shell_command for commands')
-      expect(result).toContain('Use write_file to create files')
     })
   })
 
@@ -3522,11 +3081,11 @@ Also use the Read tool to read files and Bash to run commands.`
     describe('C6: resolve_model_ids for non-Claude runtimes', () => {
       const installScript = path.resolve(process.cwd(), 'bin/install.js')
 
-      tmpdirTest('non-Claude install (opencode) writes resolve_model_ids: omit to defaults.json', async ({ tmpdir }) => {
+      tmpdirTest('non-Claude install (codex) writes resolve_model_ids: omit to defaults.json', async ({ tmpdir }) => {
         const gsdHome = path.join(tmpdir, '.gsd')
         fsSync.mkdirSync(gsdHome, { recursive: true })
 
-        execSync(`node "${installScript}" --opencode --global`, {
+        execSync(`node "${installScript}" --codex --global`, {
           env: { ...process.env, HOME: tmpdir, GSD_HOME: gsdHome },
           cwd: tmpdir,
           stdio: ['pipe', 'pipe', 'pipe'],
@@ -3566,7 +3125,7 @@ Also use the Read tool to read files and Bash to run commands.`
         const defaultsPath = path.join(gsdHome, 'defaults.json')
         fsSync.writeFileSync(defaultsPath, JSON.stringify({ existing_key: 'preserved_value' }, null, 2) + '\n')
 
-        execSync(`node "${installScript}" --opencode --global`, {
+        execSync(`node "${installScript}" --codex --global`, {
           env: { ...process.env, HOME: tmpdir, GSD_HOME: gsdHome },
           cwd: tmpdir,
           stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
- narrow installer support to Claude Code and Codex CLI only via a shared runtime-support authority
- update unit and integration regressions so `--all` and legacy runtime flags are mechanically enforced
- align live docs, capability matrix, changelog, and phase artifacts with the supported-only installer contract

## Verification
- `npx vitest run tests/unit/install.test.js`
- `npx vitest run tests/integration/multi-runtime.test.js tests/integration/cross-runtime-kb.test.js`
- phase verification report: `.planning/phases/59.1-drop-gemini-and-opencode-from-installer-scope/59.1-VERIFICATION.md`

## Notes
- Phase 59.1 passed verification with 6/6 must-haves verified.
- Auto signal collection did not run because this repo is configured at nudge level; trigger signal lifecycle remains bookkeeping lag until `\$gsdr-collect-signals 59.1` runs.