### PR TITLE
release: v1.19.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For upstream GSD changelog, see [GSD Changelog](https://github.com/glittercowboy
 
 ## [Unreleased]
 
+## [1.19.8] - 2026-04-21
+
 ### Changed
 - Installer support is now limited to Claude Code and Codex CLI. `--all` installs supported runtimes only, while `--gemini`, `--opencode`, and the legacy installer `--both` flag now fail with migration guidance instead of installing unsupported runtimes.
 

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -37,7 +37,7 @@
     "always_confirm_destructive": true,
     "always_confirm_external_services": true
   },
-  "gsd_reflect_version": "1.19.7",
+  "gsd_reflect_version": "1.19.8",
   "health_check": {
     "frequency": "milestone-only",
     "stale_threshold_days": 7,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shit-done-reflect-cc",
-  "version": "1.19.7",
+  "version": "1.19.8",
   "description": "A self-improving AI coding system that learns from its mistakes. Built on GSD by TACHES.",
   "bin": {
     "get-shit-done-reflect-cc": "bin/install.js"


### PR DESCRIPTION
## Summary
- bump package version from `1.19.7` to `1.19.8`
- stamp `get-shit-done/templates/config.json` to `gsd_reflect_version: 1.19.8`
- move the current Unreleased installer-scope change under `## [1.19.8] - 2026-04-21`

## Notes
- This follows the merged Phase 59.1 installer-scope correction on `main`.
- Main is protected, so the patch release is going through a release PR before the final tag and GitHub Release are created.

## Verification
- release diff is limited to `package.json`, `CHANGELOG.md`, and `get-shit-done/templates/config.json`