### PR TITLE
release: v1.19.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ For upstream GSD changelog, see [GSD Changelog](https://github.com/glittercowboy
 
 ## [Unreleased]
 
+## [1.19.9] - 2026-04-21
+
+### Added
+- Phase 60 sensor-pipeline and Codex parity shipping wave: cross-runtime fingerprint extraction, Codex session discovery coverage, a shared patch-classifier library, `gsd-patch-sensor`, post-install parity checks, and XRT-02 patch validation for reapply flows.
+- The Codex log-sensor path now understands cross-runtime session artifacts and ships the supporting behavior-matrix and parity research substrate from source.
+
+### Fixed
+- `gsd-tools` now lazy-loads patch-classifier surfaces so installed runtime commands outside the patches path no longer fail on source-repo-only dependencies.
+- Patch-classifier mirror coverage no longer assumes a repo-local `.codex` install mirror, bringing CI and local test expectations back into alignment.
+
 ## [1.19.8] - 2026-04-21
 
 ### Changed

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -37,7 +37,7 @@
     "always_confirm_destructive": true,
     "always_confirm_external_services": true
   },
-  "gsd_reflect_version": "1.19.8",
+  "gsd_reflect_version": "1.19.9",
   "health_check": {
     "frequency": "milestone-only",
     "stale_threshold_days": 7,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shit-done-reflect-cc",
-  "version": "1.19.8",
+  "version": "1.19.9",
   "description": "A self-improving AI coding system that learns from its mistakes. Built on GSD by TACHES.",
   "bin": {
     "get-shit-done-reflect-cc": "bin/install.js"


### PR DESCRIPTION
## Summary
- bump `package.json` to `1.19.9`
- stamp the config template version to `1.19.9`
- publish a focused changelog entry for the Phase 60 feature patch release

## Notes
- this follows the merged Phase 60 PR and is intended as an interim feature patch release
- after this PR merges, the `reflect-v1.19.9` tag and GitHub Release will be pushed from the merged state