### PR TITLE
release: v1.19.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For upstream GSD changelog, see [GSD Changelog](https://github.com/glittercowboy
 
 ## [Unreleased]
 
+## [1.19.10] - 2026-04-22
+
+### Added
+- Phase 57.9 hook-and-closeout substrate shipping wave: Claude closeout hook install wiring, Codex hook-or-waiver behavior, canonical `session_meta_postlude` records, and the aligned verifier/reference surface that closes the deferred substrate gap.
+
+### Fixed
+- Installed runtime `gsd-tools` commands no longer crash when automation loads without a source-repo `bin/install.js`; runtime mirrors now degrade safely instead of hard-failing on KB verbs and related automation entry points.
+
 ## [1.19.9] - 2026-04-21
 
 ### Added

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -37,7 +37,7 @@
     "always_confirm_destructive": true,
     "always_confirm_external_services": true
   },
-  "gsd_reflect_version": "1.19.9",
+  "gsd_reflect_version": "1.19.10",
   "health_check": {
     "frequency": "milestone-only",
     "stale_threshold_days": 7,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "get-shit-done-reflect-cc",
-  "version": "1.19.9",
+  "version": "1.19.10",
   "description": "A self-improving AI coding system that learns from its mistakes. Built on GSD by TACHES.",
   "bin": {
     "get-shit-done-reflect-cc": "bin/install.js"


### PR DESCRIPTION
## Summary
- bump `package.json` to `1.19.10`
- stamp the config template version to `1.19.10`
- publish a focused changelog entry for the Phase 57.9 feature patch release

## Notes
- this follows the merged Phase 57.9 PR and is intended as an interim feature patch release
- after this PR merges, the `reflect-v1.19.10` tag and GitHub Release will be pushed from the merged state

## Verification
- release diff is limited to `package.json`, `CHANGELOG.md`, and `get-shit-done/templates/config.json`